### PR TITLE
Refactor track views: add available tracks endpoint and reorganize frontend pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The backend provides the following main endpoints:
 - `GET /api/tracks` - List all tracks owned by the current user
 - `GET /api/tracks/public` - List all public tracks
 - `GET /api/tracks/shared` - List all tracks shared with the current user
-- `GET /api/tracks/all` - List all tracks that are accessible to the current user
+- `GET /api/tracks/available` - List all tracks that are accessible to the current user
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ The backend provides the following main endpoints:
 
 ### Tracks
 
-- `GET /api/tracks` - List all tracks for the current user
+- `GET /api/tracks` - List all tracks owned by the current user
 - `GET /api/tracks/public` - List all public tracks
-- `GET /api/tracks/shared` - List all shared tracks for the current user
+- `GET /api/tracks/shared` - List all tracks shared with the current user
+- `GET /api/tracks/all` - List all tracks that are accessible to the current user
 
 ## Troubleshooting
 

--- a/packages/backend/src/routes/tracks.ts
+++ b/packages/backend/src/routes/tracks.ts
@@ -93,7 +93,7 @@ router.get("/shared", async (req: Request, res: Response, next) => {
 });
 
 // Get all tracks accessible to the current user
-router.get("/all", async (req: Request, res: Response, next) => {
+router.get("/available", async (req: Request, res: Response, next) => {
   try {
     const allTracks = await prisma.track.findMany({
       where: {

--- a/packages/backend/src/routes/tracks.ts
+++ b/packages/backend/src/routes/tracks.ts
@@ -29,7 +29,7 @@ router.get("/public", async (req: Request, res: Response) => {
 // Apply authentication middleware for all other routes
 router.use(authenticate);
 
-// Get all tracks
+// Get all tracks owned by the current user
 router.get("/", async (req, res, next) => {
   try {
     const tracks = await prisma.track.findMany({
@@ -87,6 +87,33 @@ router.get("/shared", async (req: Request, res: Response, next) => {
       },
     });
     res.json(sharedTracks);
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Get all tracks accessible to the current user
+router.get("/all", async (req: Request, res: Response, next) => {
+  try {
+    const allTracks = await prisma.track.findMany({
+      where: {
+        OR: [
+          { userId: req.user!.id },
+          { isPublic: true },
+          { sharedWith: { some: { userId: req.user!.id } } },
+        ],
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            email: true,
+          },
+        },
+      },
+    });
+    res.json(allTracks);
   } catch (error) {
     next(error);
   }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { TrackDetails } from "@/pages/TrackDetails";
 import { Login } from "@/pages/Login";
 import { Register } from "@/pages/Register";
 import { UploadTrack } from "@/pages/UploadTrack";
+import { MyTracks } from "./pages/MyTracks";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -34,6 +35,7 @@ function AppRoutes() {
         <Route path="/register" element={<Register />} />
         <Route path="/" element={<Home />} />
         <Route path="/track/:id" element={<TrackDetails />} />
+        <Route path="/my-tracks" element={<MyTracks />} />
         <Route
           path="/upload"
           element={

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -107,8 +107,8 @@ export const api = {
       return apiRequest("/tracks/shared", { token }) as Promise<Track[]>;
     },
 
-    listAll: async (token: string) => {
-      return apiRequest("/tracks/all", { token }) as Promise<Track[]>;
+    listAvailable: async (token: string) => {
+      return apiRequest("/tracks/available", { token }) as Promise<Track[]>;
     },
   },
 

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -106,6 +106,10 @@ export const api = {
     listShared: async (token: string) => {
       return apiRequest("/tracks/shared", { token }) as Promise<Track[]>;
     },
+
+    listAll: async (token: string) => {
+      return apiRequest("/tracks/all", { token }) as Promise<Track[]>;
+    },
   },
 
   users: {

--- a/packages/frontend/src/components/track-list/TrackList.tsx
+++ b/packages/frontend/src/components/track-list/TrackList.tsx
@@ -1,0 +1,58 @@
+import { Link } from "react-router-dom";
+import { Track } from "../../types";
+import { LoadingState } from "../ui/LoadingState";
+import { ErrorState } from "../ui/ErrorState";
+
+export function TrackList({ tracks }: { tracks: Track[] }) {
+  if (!tracks?.length)
+    return <div className="text-gray-500">No tracks found</div>;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {tracks.map((track) => (
+        <Link
+          key={track.id}
+          to={`/track/${track.id}`}
+          className="block p-4 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
+        >
+          <div className="flex items-center space-x-4">
+            {track.coverArt && (
+              <img
+                src={track.coverArt}
+                alt={`${track.title} cover art`}
+                className="h-16 w-16 rounded object-cover"
+              />
+            )}
+            <div>
+              <h3 className="font-medium">{track.title}</h3>
+              <p className="text-sm text-gray-600">{track.artist}</p>
+              <p className="text-xs text-gray-500">by {track.user.username}</p>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+export function TrackSection({
+  title,
+  tracks,
+  isLoading,
+  error,
+}: {
+  title: string;
+  tracks: Track[] | undefined;
+  isLoading: boolean;
+  error: unknown;
+}) {
+  if (isLoading) return <LoadingState />;
+  if (error) return <ErrorState message={(error as Error).message} />;
+
+  return (
+    <div className="mb-12">
+      <h2 className="text-2xl font-bold mb-6">{title}</h2>
+      <TrackList tracks={tracks || []} />
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,89 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
-import { Track } from "@/types";
-import { useAuthToken } from "../hooks/useAuthToken";
-import { api } from "../api/client";
-import { LoadingState } from "../components/ui/LoadingState";
-import { ErrorState } from "../components/ui/ErrorState";
+import { useAuthToken } from "@/hooks/useAuthToken";
+import { api } from "@/api/client";
+import { TrackList, TrackSection } from "@/components/track-list/TrackList";
+import { LoadingState } from "@/components/ui/LoadingState";
+import { ErrorState } from "@/components/ui/ErrorState";
 
-function TrackList({ tracks }: { tracks: Track[] }) {
-  if (!tracks?.length)
-    return <div className="text-gray-500">No tracks found</div>;
-
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {tracks.map((track) => (
-        <Link
-          key={track.id}
-          to={`/track/${track.id}`}
-          className="block p-4 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
-        >
-          <div className="flex items-center space-x-4">
-            {track.coverArt && (
-              <img
-                src={track.coverArt}
-                alt={`${track.title} cover art`}
-                className="h-16 w-16 rounded object-cover"
-              />
-            )}
-            <div>
-              <h3 className="font-medium">{track.title}</h3>
-              <p className="text-sm text-gray-600">{track.artist}</p>
-              <p className="text-xs text-gray-500">by {track.user.username}</p>
-            </div>
-          </div>
-        </Link>
-      ))}
-    </div>
-  );
-}
-
-function TrackSection({
-  title,
-  tracks,
-  isLoading,
-  error,
-}: {
-  title: string;
-  tracks: Track[] | undefined;
-  isLoading: boolean;
-  error: unknown;
-}) {
-  if (isLoading) return <LoadingState />;
-  if (error) return <ErrorState message={(error as Error).message} />;
-
-  return (
-    <div className="mb-12">
-      <h2 className="text-2xl font-bold mb-6">{title}</h2>
-      <TrackList tracks={tracks || []} />
-    </div>
-  );
-}
-
-export function Home() {
-  const { getToken } = useAuthToken();
-  const token = getToken();
-
-  const {
-    data: userTracks,
-    isLoading: isLoadingUserTracks,
-    error: userTracksError,
-  } = useQuery({
-    queryKey: ["tracks", token],
-    queryFn: async () => (token ? api.tracks.list(token) : undefined),
-    enabled: !!token,
-  });
-
-  const {
-    data: sharedTracks,
-    isLoading: isLoadingSharedTracks,
-    error: sharedTracksError,
-  } = useQuery({
-    queryKey: ["shared-tracks", token],
-    queryFn: async () => (token ? api.tracks.listShared(token) : undefined),
-    enabled: !!token,
-  });
-
+function PublicTracks() {
   const {
     data: publicTracks,
     isLoading: isLoadingPublicTracks,
@@ -93,37 +15,47 @@ export function Home() {
     queryFn: () => api.tracks.listPublic(),
   });
 
-  if (!token) {
-    return (
-      <div className="container mx-auto px-4 py-8">
-        <h1 className="text-2xl font-bold mb-6">Public Tracks</h1>
-        <TrackList tracks={publicTracks || []} />
-      </div>
-    );
-  }
+  if (isLoadingPublicTracks) return <LoadingState />;
+  if (publicTracksError)
+    return <ErrorState message={(publicTracksError as Error).message} />;
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <TrackSection
-        title="Your Tracks"
-        tracks={userTracks}
-        isLoading={isLoadingUserTracks}
-        error={userTracksError}
-      />
-
-      <TrackSection
-        title="Shared With You"
-        tracks={sharedTracks}
-        isLoading={isLoadingSharedTracks}
-        error={sharedTracksError}
-      />
-
-      <TrackSection
-        title="Public Tracks"
-        tracks={publicTracks}
-        isLoading={isLoadingPublicTracks}
-        error={publicTracksError}
-      />
+      <h1 className="text-2xl font-bold mb-6">Public Tracks</h1>
+      <TrackList tracks={publicTracks || []} />
     </div>
   );
+}
+
+function AllTracks() {
+  const {
+    data: publicTracks,
+    isLoading: isLoadingPublicTracks,
+    error: publicTracksError,
+  } = useQuery({
+    queryKey: ["public-tracks"],
+    queryFn: () => api.tracks.listPublic(),
+  });
+
+  if (isLoadingPublicTracks) return <LoadingState />;
+  if (publicTracksError)
+    return <ErrorState message={(publicTracksError as Error).message} />;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-6">All Tracks</h1>
+      <TrackList tracks={publicTracks || []} />
+    </div>
+  );
+}
+
+export function Home() {
+  const { getToken } = useAuthToken();
+  const token = getToken();
+
+  if (!token) {
+    return <PublicTracks />;
+  }
+
+  return <AllTracks />;
 }

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -27,24 +27,25 @@ function PublicTracks() {
   );
 }
 
-function AllTracks() {
+function AllTracks({ token }: { token: string }) {
   const {
-    data: publicTracks,
-    isLoading: isLoadingPublicTracks,
-    error: publicTracksError,
+    data: allTracks,
+    isLoading: isLoadingAllTracks,
+    error: allTracksError,
   } = useQuery({
-    queryKey: ["public-tracks"],
-    queryFn: () => api.tracks.listPublic(),
+    queryKey: ["all-tracks", token],
+    queryFn: () => api.tracks.listAll(token),
+    // enabled: !!token,
   });
 
-  if (isLoadingPublicTracks) return <LoadingState />;
-  if (publicTracksError)
-    return <ErrorState message={(publicTracksError as Error).message} />;
+  if (isLoadingAllTracks) return <LoadingState />;
+  if (allTracksError)
+    return <ErrorState message={(allTracksError as Error).message} />;
 
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-6">All Tracks</h1>
-      <TrackList tracks={publicTracks || []} />
+      <TrackList tracks={allTracks || []} />
     </div>
   );
 }
@@ -57,5 +58,5 @@ export function Home() {
     return <PublicTracks />;
   }
 
-  return <AllTracks />;
+  return <AllTracks token={token} />;
 }

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { api } from "@/api/client";
-import { TrackList, TrackSection } from "@/components/track-list/TrackList";
+import { TrackList } from "@/components/track-list/TrackList";
 import { LoadingState } from "@/components/ui/LoadingState";
 import { ErrorState } from "@/components/ui/ErrorState";
 
@@ -27,25 +27,25 @@ function PublicTracks() {
   );
 }
 
-function AllTracks({ token }: { token: string }) {
+function AvailableTracks({ token }: { token: string }) {
   const {
-    data: allTracks,
-    isLoading: isLoadingAllTracks,
-    error: allTracksError,
+    data: availableTracks,
+    isLoading: isLoadingAvailableTracks,
+    error: availableTracksError,
   } = useQuery({
-    queryKey: ["all-tracks", token],
-    queryFn: () => api.tracks.listAll(token),
+    queryKey: ["available-tracks", token],
+    queryFn: () => api.tracks.listAvailable(token),
     // enabled: !!token,
   });
 
-  if (isLoadingAllTracks) return <LoadingState />;
-  if (allTracksError)
-    return <ErrorState message={(allTracksError as Error).message} />;
+  if (isLoadingAvailableTracks) return <LoadingState />;
+  if (availableTracksError)
+    return <ErrorState message={(availableTracksError as Error).message} />;
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6">All Tracks</h1>
-      <TrackList tracks={allTracks || []} />
+      <h1 className="text-2xl font-bold mb-6">Available Tracks</h1>
+      <TrackList tracks={availableTracks || []} />
     </div>
   );
 }
@@ -58,5 +58,5 @@ export function Home() {
     return <PublicTracks />;
   }
 
-  return <AllTracks token={token} />;
+  return <AvailableTracks token={token} />;
 }

--- a/packages/frontend/src/pages/MyTracks.tsx
+++ b/packages/frontend/src/pages/MyTracks.tsx
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuthToken } from "../hooks/useAuthToken";
+import { api } from "../api/client";
+import { TrackSection } from "../components/track-list/TrackList";
+
+export function MyTracks() {
+  const { getToken } = useAuthToken();
+  const token = getToken();
+
+  const {
+    data: userTracks,
+    isLoading: isLoadingUserTracks,
+    error: userTracksError,
+  } = useQuery({
+    queryKey: ["tracks", token],
+    queryFn: async () => (token ? api.tracks.list(token) : undefined),
+    enabled: !!token,
+  });
+
+  const {
+    data: sharedTracks,
+    isLoading: isLoadingSharedTracks,
+    error: sharedTracksError,
+  } = useQuery({
+    queryKey: ["shared-tracks", token],
+    queryFn: async () => (token ? api.tracks.listShared(token) : undefined),
+    enabled: !!token,
+  });
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <TrackSection
+        title="Your Tracks"
+        tracks={userTracks}
+        isLoading={isLoadingUserTracks}
+        error={userTracksError}
+      />
+
+      <TrackSection
+        title="Shared With You"
+        tracks={sharedTracks}
+        isLoading={isLoadingSharedTracks}
+        error={sharedTracksError}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces a new consolidated track view and improves the organization of track-related features.

Key Changes:
- Added new `/api/tracks/available` endpoint that returns all accessible tracks (owned, public, and shared) in a single query
- Refactored Home page to show either public tracks (logged out) or all available tracks (logged in)
- Created new MyTracks page to separately display owned and shared tracks
- Extracted TrackList component to reduce code duplication
- Updated API documentation in README to clarify track endpoint behaviors

The changes improve the user experience by providing a unified view of all accessible tracks while maintaining the ability to separately view owned and shared tracks.