### PR TITLE
Implement secure cover art access with authentication

### DIFF
--- a/packages/frontend/src/components/track-details/TrackHeader.tsx
+++ b/packages/frontend/src/components/track-details/TrackHeader.tsx
@@ -1,15 +1,25 @@
+import { useAuthToken } from "@/hooks/useAuthToken";
+
 interface TrackHeaderProps {
   title: string;
   artist: string;
   coverArt?: string | null;
+  trackId: string;
 }
 
-export function TrackHeader({ title, artist, coverArt }: TrackHeaderProps) {
+export function TrackHeader({
+  title,
+  artist,
+  coverArt,
+  trackId,
+}: TrackHeaderProps) {
+  const { appendTokenToUrl } = useAuthToken();
+
   return (
     <div className="flex items-center space-x-4 p-4">
       {coverArt && (
         <img
-          src={coverArt}
+          src={appendTokenToUrl(`/api/track/${trackId}/cover`)}
           alt={`${title} cover art`}
           className="h-24 w-24 rounded-lg object-cover"
         />

--- a/packages/frontend/src/components/track-list/TrackList.tsx
+++ b/packages/frontend/src/components/track-list/TrackList.tsx
@@ -2,8 +2,11 @@ import { Link } from "react-router-dom";
 import { Track } from "../../types";
 import { LoadingState } from "../ui/LoadingState";
 import { ErrorState } from "../ui/ErrorState";
+import { useAuthToken } from "@/hooks/useAuthToken";
 
 export function TrackList({ tracks }: { tracks: Track[] }) {
+  const { appendTokenToUrl } = useAuthToken();
+
   if (!tracks?.length)
     return <div className="text-gray-500">No tracks found</div>;
 
@@ -18,7 +21,7 @@ export function TrackList({ tracks }: { tracks: Track[] }) {
           <div className="flex items-center space-x-4">
             {track.coverArt && (
               <img
-                src={track.coverArt}
+                src={appendTokenToUrl(`/api/track/${track.id}/cover`)}
                 alt={`${track.title} cover art`}
                 className="h-16 w-16 rounded object-cover"
               />

--- a/packages/frontend/src/pages/TrackDetails.tsx
+++ b/packages/frontend/src/pages/TrackDetails.tsx
@@ -52,6 +52,7 @@ export function TrackDetails() {
           title={track.title}
           artist={track.artist}
           coverArt={track.coverArt}
+          trackId={track.id}
         />
         <FullTrackSection track={track} />
         <ComponentsSection


### PR DESCRIPTION
Adds secure access to track cover art images by:
- Adding new `/track/:id/cover` endpoint with authentication middleware
- Updating frontend components to fetch cover art through authenticated URLs
- Supporting multiple image formats (png, jpg, jpeg, gif, webp, svg)

This ensures cover art images are only accessible to authorized users while maintaining proper content type handling.