### PR TITLE
Change backend API port to 3002 and enhance deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ pnpm dev
 Services will be available at:
 
 - Frontend: http://localhost:5173
-- Backend API: http://localhost:3000
+- Backend API: http://localhost:3002
 - Media Service: http://localhost:3001 (when running locally)
 - PostgreSQL: localhost:5432
 - MinIO: localhost:9000 (API) and localhost:9001 (Console)
@@ -253,7 +253,7 @@ MINIO_BUCKET="wavtopia"
 EXPORT_TO_WAV_PATH="/usr/local/bin/export-to-wav"
 
 # packages/frontend/.env
-VITE_API_URL="http://localhost:3000"
+VITE_API_URL="http://localhost:3002"
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         - WORKSPACE_IMAGE=${REGISTRY_PREFIX:-}wavtopia-workspace
     image: ${REGISTRY_PREFIX:-}wavtopia-backend
     ports:
-      - "3000:3000"
+      - "3002:3002"
     volumes:
       - temp_files:/tmp
     networks:

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,5 +1,5 @@
 # Server
-PORT=3000
+PORT=3002
 
 # Media service
 MEDIA_SERVICE_URL="http://localhost:3001"

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const ServerConfigSchema = z.object({
-  port: z.number().default(3000),
+  port: z.number().default(3002),
   // TODO: Remove jwtSecret if we don't need it
   jwtSecret: z.string().default("your-secret-key"),
 });
@@ -22,7 +22,7 @@ export type SharedConfig = z.infer<typeof SharedConfigSchema>;
 function loadConfig(): SharedConfig {
   return SharedConfigSchema.parse({
     server: {
-      port: parseInt(process.env.PORT || "3000"),
+      port: parseInt(process.env.PORT || "3002"),
       jwtSecret: process.env.JWT_SECRET || "your-secret-key",
     },
     services: {

--- a/packages/frontend/nginx.conf
+++ b/packages/frontend/nginx.conf
@@ -19,7 +19,7 @@ http {
 
         # Backend API proxy
         location /api {
-            proxy_pass http://backend:3000;
+            proxy_pass http://backend:3002;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        target: "http://localhost:3002",
         changeOrigin: true,
         timeout: 300000,
         proxyTimeout: 300000,

--- a/packages/media/.env.example
+++ b/packages/media/.env.example
@@ -1,5 +1,5 @@
 # Server
-PORT=3000
+PORT=3002
 
 # Database
 DATABASE_URL="postgresql://wavtopia:wavtopia@localhost:5432/wavtopia"

--- a/packages/media/src/config.ts
+++ b/packages/media/src/config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const ServerConfigSchema = z.object({
-  port: z.number().default(3000),
+  port: z.number().default(3002),
   // TODO: Remove jwtSecret if we don't need it
   jwtSecret: z.string().default("your-secret-key"),
 });

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -108,6 +108,9 @@ test_registry() {
     
     # Set up SSH tunnel
     setup_tunnel "$REMOTE_HOST"
+
+    # Get actual registry port
+    REGISTRY_PORT=$(get_registry_port)
     
     echo "Testing registry API..."
     curl -v http://localhost:${REGISTRY_PORT}/v2/ || {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -256,12 +256,14 @@ deploy_prod() {
     docker push "${REGISTRY}/wavtopia-media"
     docker push "${REGISTRY}/wavtopia-backend"
 
-    # Update docker-compose to use the remote registry address
-    export REGISTRY_PREFIX="${REMOTE_HOSTNAME}:${REGISTRY_PORT}/"
-
     # Switch to production context and deploy
     echo "Deploying services..."
     docker context use production
+    
+    # Use localhost for registry when deploying since we're on the remote host
+    export REGISTRY_PREFIX="localhost:${REGISTRY_PORT}/"
+    echo "Using registry at ${REGISTRY_PREFIX}"
+    
     docker compose --profile production up -d
 
     # Switch back to default context

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -106,11 +106,12 @@ test_registry() {
     # Get the remote host from the current context
     REMOTE_HOST=$(docker context inspect production --format '{{.Endpoints.docker.Host}}' | sed 's|ssh://||' | cut -d':' -f1)
     
+    # Get actual registry port before setting up tunnel
+    REGISTRY_PORT=$(get_registry_port)
+    echo "Detected registry port: ${REGISTRY_PORT}"
+    
     # Set up SSH tunnel
     setup_tunnel "$REMOTE_HOST"
-
-    # Get actual registry port
-    REGISTRY_PORT=$(get_registry_port)
     
     echo "Testing registry API..."
     curl -v http://localhost:${REGISTRY_PORT}/v2/ || {
@@ -224,8 +225,9 @@ deploy_prod() {
     REMOTE_USER=$(echo "$REMOTE_HOST" | cut -d'@' -f1)
     REMOTE_HOSTNAME=$(echo "$REMOTE_HOST" | cut -d'@' -f2)
     
-    # Get actual registry port
+    # Get actual registry port before setting up tunnel
     REGISTRY_PORT=$(get_registry_port)
+    echo "Detected registry port: ${REGISTRY_PORT}"
     REGISTRY="localhost:${REGISTRY_PORT}"
 
     # Set up SSH tunnel

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -132,13 +132,13 @@ test_registry() {
 # Function to get registry port from container
 get_registry_port() {
     # Try to get the host port from container inspection
-    local port=$(docker --context production inspect registry 2>/dev/null | grep -o '"HostPort": "[^"]*"' | cut -d'"' -f4)
+    local port=$(docker --context production inspect registry 2>/dev/null | grep -o '"HostPort": "[^"]*"' | cut -d'"' -f4 | tr -d '\n\r')
     if [ -n "$port" ]; then
-        echo "$port"
+        echo -n "$port"
         return 0
     fi
     # Fallback to default port
-    echo "${REGISTRY_PORT}"
+    echo -n "${REGISTRY_PORT}"
 }
 
 # Function to setup remote context

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -131,9 +131,9 @@ test_registry() {
 
 # Function to get registry port from container
 get_registry_port() {
-    # Try to get the host port from container inspection
-    local port=$(docker --context production inspect registry 2>/dev/null | grep -o '"HostPort": "[^"]*"' | cut -d'"' -f4 | tr -d '\n\r')
-    if [ -n "$port" ]; then
+    # Try to get the host port from container inspection using jq
+    local port=$(docker --context production inspect registry 2>/dev/null | jq -r '.[0].NetworkSettings.Ports."5000/tcp"[0].HostPort')
+    if [ "$port" != "null" ] && [ -n "$port" ]; then
         echo -n "$port"
         return 0
     fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -61,7 +61,7 @@ setup_tunnel() {
     
     # Start new tunnel with verbose output
     echo "Creating SSH tunnel to ${remote_host}..."
-    ssh -v -f -N -L "${REGISTRY_PORT}:localhost:${REGISTRY_PORT}" "$remote_host"
+    ssh -f -N -L "${REGISTRY_PORT}:localhost:${REGISTRY_PORT}" "$remote_host"
     if [ $? -ne 0 ]; then
         echo "Failed to establish SSH tunnel"
         exit 1


### PR DESCRIPTION
- Changed backend API port from 3000 to 3002 across all configurations
- Enhanced deployment script with improved registry handling and error detection:
  - Added new `test-registry` command to verify registry connectivity
  - Improved SSH tunnel setup with better error handling and status checks
  - Added dynamic registry port detection from running container
  - Enhanced registry health checks during setup and deployment
  - Fixed networking configuration for registry container to use host network
  - Improved error messages and logging during deployment process