### PR TITLE
Add bulk upload functionality for tracks

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { FeatureFlagsAdmin } from "@/pages/Admin/FeatureFlags";
 import { InviteCodesAdmin } from "@/pages/Admin/InviteCodes";
 import { RequestEarlyAccess } from "@/pages/RequestEarlyAccess";
 import Notifications from "@/pages/Notifications";
+import { BulkUploadTrack } from "./pages/BulkUploadTrack";
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuth();
@@ -56,6 +57,14 @@ function AppRoutes() {
           element={
             <PrivateRoute>
               <UploadTrack />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/upload/bulk"
+          element={
+            <PrivateRoute>
+              <BulkUploadTrack />
             </PrivateRoute>
           }
         />

--- a/packages/frontend/src/pages/BulkUploadTrack.tsx
+++ b/packages/frontend/src/pages/BulkUploadTrack.tsx
@@ -1,0 +1,206 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { FormInput, FormError, FormButton } from "@/components/ui/FormInput";
+import { useAuthToken } from "@/hooks/useAuthToken";
+import { api } from "@/api/client";
+
+interface FileMatch {
+  track: File;
+  coverArt?: File;
+  title: string; // Derived from filename
+}
+
+interface BulkUploadState {
+  defaultArtist: string;
+  matches: FileMatch[];
+  currentUploadIndex: number;
+  uploadedTracks: string[]; // Track IDs
+  error?: string;
+}
+
+export function BulkUploadTrack() {
+  const navigate = useNavigate();
+  const { getToken } = useAuthToken();
+  const [state, setState] = useState<BulkUploadState>({
+    defaultArtist: "",
+    matches: [],
+    currentUploadIndex: -1,
+    uploadedTracks: [],
+  });
+
+  // Match .xm files with their cover art
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    const trackFiles = new Map<string, File>();
+    const artFiles = new Map<string, File>();
+
+    // Sort files into tracks and art
+    files.forEach((file) => {
+      const ext = file.name.split(".").pop()?.toLowerCase();
+      const baseName = file.name.substring(0, file.name.lastIndexOf("."));
+
+      if (ext === "xm") {
+        trackFiles.set(baseName, file);
+      } else if (file.type.startsWith("image/")) {
+        artFiles.set(baseName, file);
+      }
+    });
+
+    // Match tracks with art
+    const matches: FileMatch[] = [];
+    trackFiles.forEach((trackFile, baseName) => {
+      matches.push({
+        track: trackFile,
+        coverArt: artFiles.get(baseName),
+        title: baseName,
+      });
+    });
+
+    setState((prev) => ({
+      ...prev,
+      matches,
+      currentUploadIndex: -1,
+      uploadedTracks: [],
+    }));
+  };
+
+  // Start the upload process
+  const startUpload = async () => {
+    setState((prev) => ({ ...prev, currentUploadIndex: 0 }));
+    await uploadNext();
+  };
+
+  // Upload the next track in the queue
+  const uploadNext = async () => {
+    const { matches, currentUploadIndex, defaultArtist } = state;
+    if (currentUploadIndex >= matches.length) return;
+
+    const match = matches[currentUploadIndex];
+    const formData = new FormData();
+
+    formData.append(
+      "data",
+      JSON.stringify({
+        title: match.title,
+        artist: defaultArtist,
+        originalFormat: "xm",
+      })
+    );
+
+    formData.append("original", match.track);
+    if (match.coverArt) {
+      formData.append("coverArt", match.coverArt);
+    }
+
+    try {
+      const data = await api.track.upload(formData, getToken()!);
+      setState((prev) => ({
+        ...prev,
+        uploadedTracks: [...prev.uploadedTracks, data.id],
+        currentUploadIndex: prev.currentUploadIndex + 1,
+      }));
+
+      // Continue with next file if there are more
+      if (currentUploadIndex + 1 < matches.length) {
+        await uploadNext();
+      }
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        error: `Failed to upload ${match.title}: ${error}`,
+      }));
+    }
+  };
+
+  const progress =
+    state.currentUploadIndex === -1
+      ? 0
+      : (state.currentUploadIndex / state.matches.length) * 100;
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h1 className="text-3xl font-bold mb-8">Bulk Upload Tracks</h1>
+
+      <div className="space-y-6">
+        <FormInput
+          id="files"
+          type="file"
+          label="Select Track Files (.xm) and Cover Art"
+          accept=".xm,image/*"
+          multiple
+          onChange={handleFileSelect}
+        />
+
+        <FormInput
+          id="defaultArtist"
+          type="text"
+          label="Default Artist (optional)"
+          value={state.defaultArtist}
+          onChange={(e) =>
+            setState((prev) => ({
+              ...prev,
+              defaultArtist: e.target.value,
+            }))
+          }
+        />
+
+        {state.matches.length > 0 && (
+          <div className="border rounded-lg p-4">
+            <h2 className="text-lg font-semibold mb-4">
+              Found {state.matches.length} tracks:
+            </h2>
+            <ul className="space-y-2">
+              {state.matches.map((match, i) => (
+                <li
+                  key={match.title}
+                  className={`flex items-center space-x-2 ${
+                    i < state.currentUploadIndex
+                      ? "text-green-600"
+                      : i === state.currentUploadIndex
+                      ? "text-blue-600 font-medium"
+                      : ""
+                  }`}
+                >
+                  <span>{match.title}</span>
+                  {match.coverArt && (
+                    <span className="text-sm text-gray-500">
+                      (with cover art)
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {state.error && <FormError message={state.error} />}
+
+        {state.currentUploadIndex >= 0 && (
+          <div className="w-full bg-gray-200 rounded-full h-2.5">
+            <div
+              className="bg-blue-600 h-2.5 rounded-full"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        )}
+
+        <FormButton
+          onClick={startUpload}
+          disabled={state.matches.length === 0 || state.currentUploadIndex >= 0}
+        >
+          {state.currentUploadIndex >= 0
+            ? `Uploading (${state.currentUploadIndex + 1}/${
+                state.matches.length
+              })`
+            : "Start Upload"}
+        </FormButton>
+
+        {state.uploadedTracks.length === state.matches.length && (
+          <div className="text-center text-green-600">
+            All tracks uploaded successfully!
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { FormInput, FormError, FormButton } from "@/components/ui/FormInput";
 import { useForm } from "@/hooks/useForm";
 import { useAuthToken } from "@/hooks/useAuthToken";
@@ -107,6 +107,16 @@ export function UploadTrack() {
         <FormButton type="submit" disabled={isSubmitting}>
           {isSubmitting ? "Uploading..." : "Upload Track"}
         </FormButton>
+
+        <p className="text-center text-sm mt-4">
+          Need to upload multiple tracks?{" "}
+          <Link
+            to="/upload/bulk"
+            className="text-primary-600 hover:text-primary-700"
+          >
+            Try bulk upload
+          </Link>
+        </p>
       </form>
     </div>
   );


### PR DESCRIPTION
**Changes:**
- Add new `/upload/bulk` route with bulk upload interface
- Create BulkUploadTrack component for handling multiple file uploads
- Support matching .xm track files with corresponding cover art files
- Add link to bulk upload from single upload page
- Show upload progress and status for each track

**Features:**
- Upload multiple .xm files simultaneously
- Automatic matching of cover art files with track files
- Set default artist name for all uploads
- Real-time progress tracking
- Error handling for failed uploads
- Visual feedback for upload status

**Technical Details:**
- Uses existing track upload API endpoint
- Maintains state of upload progress
- Handles files sequentially to prevent overwhelming the server
- Preserves original filenames as track titles