### PR TITLE
Refactor track deletion functionality to support batch deletion

### DIFF
--- a/packages/backend/src/services/track.ts
+++ b/packages/backend/src/services/track.ts
@@ -1,0 +1,99 @@
+import { prisma } from "../lib/prisma";
+import { AppError } from "../middleware/errorHandler";
+import { deleteFile } from "./storage";
+
+/**
+ * Delete all files associated with a track
+ */
+async function deleteTrackFiles(track: {
+  originalUrl: string;
+  fullTrackUrl?: string | null;
+  fullTrackMp3Url?: string | null;
+  coverArt?: string | null;
+  components: { wavUrl: string; mp3Url: string }[];
+}) {
+  await deleteFile(track.originalUrl);
+
+  if (track.fullTrackUrl) {
+    await deleteFile(track.fullTrackUrl);
+  }
+
+  if (track.fullTrackMp3Url) {
+    await deleteFile(track.fullTrackMp3Url);
+  }
+
+  if (track.coverArt) {
+    await deleteFile(track.coverArt);
+  }
+
+  for (const component of track.components) {
+    await deleteFile(component.wavUrl);
+    await deleteFile(component.mp3Url);
+  }
+}
+
+/**
+ * Delete a single track and all its associated files
+ */
+export async function deleteTrack(trackId: string, userId: string) {
+  const track = await prisma.track.findUnique({
+    where: {
+      id: trackId,
+      userId, // Only delete user's own track
+    },
+    include: { components: true },
+  });
+
+  if (!track) {
+    throw new AppError(404, "Track not found");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    // Delete all associated files
+    await deleteTrackFiles(track);
+
+    // Delete components first
+    await tx.component.deleteMany({
+      where: { trackId: track.id },
+    });
+
+    // Then delete the track
+    await tx.track.delete({
+      where: { id: trackId },
+    });
+  });
+}
+
+/**
+ * Delete multiple tracks and all their associated files
+ *
+ * TODO: Add track deletions to the bullmq queue and remove this function
+ */
+export async function deleteMultipleTracks(trackIds: string[], userId: string) {
+  const tracks = await prisma.track.findMany({
+    where: {
+      id: { in: trackIds },
+      userId, // Only delete user's own tracks
+    },
+    include: { components: true },
+  });
+
+  if (tracks.length !== trackIds.length) {
+    throw new AppError(404, "One or more tracks not found");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    // Delete all associated files for each track
+    await Promise.all(tracks.map(deleteTrackFiles));
+
+    // Delete all components for these tracks
+    await tx.component.deleteMany({
+      where: { trackId: { in: trackIds } },
+    });
+
+    // Then delete all tracks
+    await tx.track.deleteMany({
+      where: { id: { in: trackIds } },
+    });
+  });
+}

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -184,6 +184,16 @@ export const api = {
         token,
       });
     },
+
+    // TODO: Move batchDelete to tracks?
+    batchDelete: async (ids: string[], token: string) => {
+      return apiRequest("/track/batch", {
+        method: "DELETE",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify({ trackIds: ids }),
+      });
+    },
   },
 
   tracks: {
@@ -201,15 +211,6 @@ export const api = {
 
     listAvailable: async (token: string) => {
       return apiRequest("/tracks/available", { token }) as Promise<Track[]>;
-    },
-
-    batchDelete: async (ids: string[], token: string) => {
-      return apiRequest("/tracks/batch", {
-        method: "DELETE",
-        token,
-        contentType: "application/json",
-        body: JSON.stringify({ ids }),
-      });
     },
   },
 

--- a/packages/frontend/src/pages/MyTracks.tsx
+++ b/packages/frontend/src/pages/MyTracks.tsx
@@ -32,8 +32,10 @@ export function MyTracks() {
   });
 
   const deleteTrackMutation = useMutation({
-    mutationFn: async (trackId: string) => {
-      if (!token) throw new Error("No token available");
+    mutationFn: (trackId: string) => {
+      if (!token) {
+        throw new Error("No token available");
+      }
       return api.track.delete(trackId, token);
     },
     onSuccess: () => {
@@ -42,9 +44,11 @@ export function MyTracks() {
   });
 
   const deleteTracksMutation = useMutation({
-    mutationFn: async (trackIds: string[]) => {
-      if (!token) throw new Error("No token available");
-      return api.tracks.batchDelete(trackIds, token);
+    mutationFn: (trackIds: string[]) => {
+      if (!token) {
+        throw new Error("No token available");
+      }
+      return api.track.batchDelete(trackIds, token);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tracks"] });
@@ -64,12 +68,10 @@ export function MyTracks() {
     });
   };
 
-  const handleDeleteTrack = (trackId: string) => {
-    deleteTrackMutation.mutate(trackId);
-  };
-
-  const handleDeleteSelectedTracks = () => {
-    deleteTracksMutation.mutate(Array.from(selectedTracks));
+  const handleDeleteTracks = () => {
+    if (selectedTracks.size > 0) {
+      deleteTracksMutation.mutate(Array.from(selectedTracks));
+    }
   };
 
   const handleCancelSelection = () => {
@@ -88,7 +90,7 @@ export function MyTracks() {
         selectable={true}
         selectedTracks={selectedTracks}
         onTrackSelect={handleTrackSelect}
-        onDeleteTrack={handleDeleteTrack}
+        onDeleteTrack={deleteTrackMutation.mutate}
       />
 
       <TrackSection
@@ -101,7 +103,7 @@ export function MyTracks() {
       {selectedTracks.size > 0 && (
         <BatchActionsBar
           selectedCount={selectedTracks.size}
-          onDelete={handleDeleteSelectedTracks}
+          onDelete={handleDeleteTracks}
           onCancelSelection={handleCancelSelection}
         />
       )}


### PR DESCRIPTION
- Introduced a new endpoint for deleting multiple tracks and their associated files, enhancing the API's capabilities.
- Implemented `deleteMultipleTracks` service function to handle the deletion logic for multiple tracks, ensuring all related data is cleaned up.
- Updated the frontend to include a batch delete option in the MyTracks component, allowing users to select and delete multiple tracks at once.
- Refactored existing delete logic to improve code organization and maintainability, separating concerns between track deletion and file management.