### PR TITLE
Implement cursor-based pagination for track listings

### DIFF
--- a/packages/backend/src/routes/tracks.ts
+++ b/packages/backend/src/routes/tracks.ts
@@ -1,16 +1,74 @@
 import { Router, Request, Response } from "express";
 import { authenticate } from "../middleware/auth";
 import { prisma } from "../lib/prisma";
+import {
+  PaginatedResponse,
+  PaginationParams,
+  Track,
+  encodeCursor,
+  decodeCursor,
+} from "@wavtopia/core-storage";
 
 const router = Router();
+const DEFAULT_PAGE_SIZE = 20;
+
+// Helper function to handle cursor-based pagination
+async function getPaginatedTracks(
+  where: any,
+  include: any,
+  params: PaginationParams
+): Promise<PaginatedResponse<Track>> {
+  const limit = params.limit || DEFAULT_PAGE_SIZE;
+  const cursor = params.cursor ? decodeCursor(params.cursor) : null;
+
+  // Get one extra item to determine if there's a next page
+  const items = await prisma.track.findMany({
+    where: cursor
+      ? {
+          ...where,
+          OR: [
+            {
+              createdAt: { lt: cursor.date },
+            },
+            {
+              createdAt: cursor.date,
+              id: { lt: cursor.id },
+            },
+          ],
+        }
+      : where,
+    include,
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: limit + 1,
+  });
+
+  const hasNextPage = items.length > limit;
+  const paginatedItems = hasNextPage ? items.slice(0, -1) : items;
+
+  return {
+    items: paginatedItems,
+    metadata: {
+      hasNextPage,
+      nextCursor: hasNextPage
+        ? encodeCursor(
+            paginatedItems[paginatedItems.length - 1].createdAt,
+            paginatedItems[paginatedItems.length - 1].id
+          )
+        : undefined,
+    },
+  };
+}
 
 // Get public tracks
 router.get("/public", async (req: Request, res: Response) => {
-  const publicTracks = await prisma.track.findMany({
-    where: {
-      isPublic: true,
-    },
-    include: {
+  const cursor = req.query.cursor as string | undefined;
+  const limit = req.query.limit
+    ? parseInt(req.query.limit as string)
+    : undefined;
+
+  const result = await getPaginatedTracks(
+    { isPublic: true },
+    {
       user: {
         select: {
           id: true,
@@ -18,11 +76,10 @@ router.get("/public", async (req: Request, res: Response) => {
         },
       },
     },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
-  res.json(publicTracks);
+    { cursor, limit }
+  );
+
+  res.json(result);
 });
 
 // Apply authentication middleware for all other routes
@@ -31,11 +88,14 @@ router.use(authenticate);
 // Get all tracks owned by the current user
 router.get("/", async (req, res, next) => {
   try {
-    const tracks = await prisma.track.findMany({
-      where: {
-        userId: req.user!.id, // Only get user's own tracks
-      },
-      include: {
+    const cursor = req.query.cursor as string | undefined;
+    const limit = req.query.limit
+      ? parseInt(req.query.limit as string)
+      : undefined;
+
+    const result = await getPaginatedTracks(
+      { userId: req.user!.id },
+      {
         components: true,
         user: {
           select: {
@@ -45,8 +105,10 @@ router.get("/", async (req, res, next) => {
           },
         },
       },
-    });
-    res.json(tracks);
+      { cursor, limit }
+    );
+
+    res.json(result);
   } catch (error) {
     next(error);
   }
@@ -55,15 +117,20 @@ router.get("/", async (req, res, next) => {
 // Get tracks shared with the current user
 router.get("/shared", async (req: Request, res: Response, next) => {
   try {
-    const sharedTracks = await prisma.track.findMany({
-      where: {
+    const cursor = req.query.cursor as string | undefined;
+    const limit = req.query.limit
+      ? parseInt(req.query.limit as string)
+      : undefined;
+
+    const result = await getPaginatedTracks(
+      {
         sharedWith: {
           some: {
             userId: req.user!.id,
           },
         },
       },
-      include: {
+      {
         user: {
           select: {
             id: true,
@@ -84,8 +151,10 @@ router.get("/shared", async (req: Request, res: Response, next) => {
           },
         },
       },
-    });
-    res.json(sharedTracks);
+      { cursor, limit }
+    );
+
+    res.json(result);
   } catch (error) {
     next(error);
   }
@@ -94,15 +163,20 @@ router.get("/shared", async (req: Request, res: Response, next) => {
 // Get all tracks accessible to the current user
 router.get("/available", async (req: Request, res: Response, next) => {
   try {
-    const allTracks = await prisma.track.findMany({
-      where: {
+    const cursor = req.query.cursor as string | undefined;
+    const limit = req.query.limit
+      ? parseInt(req.query.limit as string)
+      : undefined;
+
+    const result = await getPaginatedTracks(
+      {
         OR: [
           { userId: req.user!.id },
           { isPublic: true },
           { sharedWith: { some: { userId: req.user!.id } } },
         ],
       },
-      include: {
+      {
         user: {
           select: {
             id: true,
@@ -111,8 +185,10 @@ router.get("/available", async (req: Request, res: Response, next) => {
           },
         },
       },
-    });
-    res.json(allTracks);
+      { cursor, limit }
+    );
+
+    res.json(result);
   } catch (error) {
     next(error);
   }

--- a/packages/backend/src/routes/tracks.ts
+++ b/packages/backend/src/routes/tracks.ts
@@ -4,20 +4,20 @@ import { prisma } from "../lib/prisma";
 import {
   PaginatedResponse,
   PaginationParams,
-  Track,
   encodeCursor,
   decodeCursor,
+  Prisma,
 } from "@wavtopia/core-storage";
 
 const router = Router();
 const DEFAULT_PAGE_SIZE = 20;
 
 // Helper function to handle cursor-based pagination
-async function getPaginatedTracks(
-  where: any,
-  include: any,
+async function getPaginatedTracks<I extends Prisma.TrackInclude>(
+  where: Prisma.TrackWhereInput,
+  include: I,
   params: PaginationParams
-): Promise<PaginatedResponse<Track>> {
+): Promise<PaginatedResponse<Prisma.TrackGetPayload<{ include: I }>>> {
   const limit = params.limit || DEFAULT_PAGE_SIZE;
   const cursor = params.cursor ? decodeCursor(params.cursor) : null;
 

--- a/packages/core-storage/prisma/migrations/20250117023422_add_track_pagination_index/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250117023422_add_track_pagination_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "tracks_created_at_id_idx" ON "tracks"("created_at", "id");

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Track {
   createdAt       DateTime     @default(now()) @map("created_at")
   updatedAt       DateTime     @updatedAt @map("updated_at")
 
+  @@index([createdAt, id])
   @@map("tracks")
 }
 

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -24,4 +24,12 @@ export {
   NotificationType,
 } from ".prisma/client";
 
+export {
+  type Track,
+  type PaginatedResponse,
+  type PaginationParams,
+  encodeCursor,
+  decodeCursor,
+} from "./types";
+
 export * from "./auth";

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -31,5 +31,4 @@ export {
   encodeCursor,
   decodeCursor,
 } from "./types";
-
 export * from "./auth";

--- a/packages/core-storage/src/types.ts
+++ b/packages/core-storage/src/types.ts
@@ -1,0 +1,50 @@
+import { Prisma } from ".prisma/client";
+
+export type Track = Prisma.TrackGetPayload<{
+  include: {
+    user: {
+      select: {
+        id: true;
+        username: true;
+        email: true;
+      };
+    };
+    components: true;
+    sharedWith: {
+      include: {
+        user: {
+          select: {
+            id: true;
+            username: true;
+            email: true;
+          };
+        };
+      };
+    };
+  };
+}>;
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  metadata: {
+    hasNextPage: boolean;
+    nextCursor?: string;
+  };
+}
+
+export interface PaginationParams {
+  cursor?: string;
+  limit?: number;
+}
+
+export function encodeCursor(date: Date, id: string): string {
+  return Buffer.from(`${date.toISOString()}_${id}`).toString("base64");
+}
+
+export function decodeCursor(cursor: string): { date: Date; id: string } {
+  const [dateStr, id] = Buffer.from(cursor, "base64").toString().split("_");
+  return {
+    date: new Date(dateStr),
+    id,
+  };
+}

--- a/packages/core-storage/types/index.d.ts
+++ b/packages/core-storage/types/index.d.ts
@@ -3,4 +3,5 @@ export { PrismaService } from "./services/prisma";
 export { deleteLocalFile, ensureDirectoryExists, normalizeFilePath, } from "./services/local-storage";
 export { config, type StorageConfig, type DatabaseConfig, type RedisConfig, type SharedConfig, } from "./config";
 export { Prisma, User, Role, InviteCode, FeatureFlag, Notification, NotificationType, } from ".prisma/client";
+export { type Track, type PaginatedResponse, type PaginationParams, encodeCursor, decodeCursor, } from "./types";
 export * from "./auth";

--- a/packages/core-storage/types/types.d.ts
+++ b/packages/core-storage/types/types.d.ts
@@ -1,2 +1,40 @@
-import { User, FeatureFlag, InviteCode } from "../node_modules/.prisma/client";
-export type { User, FeatureFlag, InviteCode };
+import { Prisma } from ".prisma/client";
+export type Track = Prisma.TrackGetPayload<{
+    include: {
+        user: {
+            select: {
+                id: true;
+                username: true;
+                email: true;
+            };
+        };
+        components: true;
+        sharedWith: {
+            include: {
+                user: {
+                    select: {
+                        id: true;
+                        username: true;
+                        email: true;
+                    };
+                };
+            };
+        };
+    };
+}>;
+export interface PaginatedResponse<T> {
+    items: T[];
+    metadata: {
+        hasNextPage: boolean;
+        nextCursor?: string;
+    };
+}
+export interface PaginationParams {
+    cursor?: string;
+    limit?: number;
+}
+export declare function encodeCursor(date: Date, id: string): string;
+export declare function decodeCursor(cursor: string): {
+    date: Date;
+    id: string;
+};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-switch": "^1.1.2",
+    "@radix-ui/react-tabs": "^1.1.2",
     "@tanstack/react-query": "^5.62.14",
     "@wavtopia/core-storage": "workspace:*",
     "clsx": "^2.1.1",

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -1,62 +1,210 @@
-import { Track, PaginatedResponse, PaginationParams } from "../types";
+import { PaginationParams, Track, User, PaginatedResponse } from "../types";
 
-const API_BASE_URL = "/api";
+const API_URL = "/api";
 
-async function handleResponse<T>(response: Response): Promise<T> {
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({}));
-    throw new Error(error.message || response.statusText);
-  }
-  return response.json();
+interface FetchOptions extends RequestInit {
+  token?: string | null;
+  searchParams?: URLSearchParams;
+  contentType?: string;
 }
+
+const apiRequest = async (endpoint: string, options: FetchOptions = {}) => {
+  const {
+    token,
+    searchParams,
+    contentType,
+    headers: customHeaders = {},
+    ...rest
+  } = options;
+
+  const headers = new Headers(customHeaders);
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+
+  const url = new URL(`${API_URL}${endpoint}`);
+  if (searchParams) {
+    url.search = searchParams.toString();
+  }
+
+  const response = await fetch(url.toString(), {
+    headers,
+    ...rest,
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.statusText}`);
+  }
+
+  return response.json();
+};
 
 export const api = {
   auth: {
     login: async (email: string, password: string) => {
-      const response = await fetch(`${API_BASE_URL}/auth/login`, {
+      return apiRequest("/auth/login", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        contentType: "application/json",
         body: JSON.stringify({ email, password }),
       });
-      return handleResponse<{ token: string; user: any }>(response);
     },
 
-    register: async (data: {
-      email: string;
-      username: string;
-      password: string;
-      inviteCode?: string;
-    }) => {
-      const response = await fetch(`${API_BASE_URL}/auth/register`, {
+    register: async (
+      email: string,
+      username: string,
+      password: string,
+      inviteCode?: string
+    ) => {
+      // TODO: Rename the route to /auth/register, as the page is also called Register.
+      // Will need a documentation update.
+      return apiRequest("/auth/signup", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
+        contentType: "application/json",
+        body: JSON.stringify({ email, username, password, inviteCode }),
       });
-      return handleResponse<{ token: string; user: any }>(response);
+    },
+
+    requestEarlyAccess: async (email: string) => {
+      return apiRequest("/auth/request-early-access", {
+        method: "POST",
+        contentType: "application/json",
+        body: JSON.stringify({ email }),
+      }) as Promise<{ success: boolean }>;
     },
 
     me: async (token: string) => {
-      const response = await fetch(`${API_BASE_URL}/auth/me`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-      return handleResponse<{ user: any }>(response);
+      return apiRequest("/auth/me", { token });
     },
 
     getEnabledFeatures: async (token: string | null) => {
-      const response = await fetch(`${API_BASE_URL}/auth/features`, {
-        headers: token
-          ? {
-              Authorization: `Bearer ${token}`,
-            }
-          : {},
+      return apiRequest("/auth/enabled-features", { token }) as Promise<{
+        flags: string[];
+      }>;
+    },
+  },
+
+  admin: {
+    getFeatureFlags: async (token: string) => {
+      return apiRequest("/admin/feature-flags", { token });
+    },
+
+    createFeatureFlag: async (
+      token: string,
+      data: {
+        name: string;
+        description?: string;
+        isEnabled?: boolean;
+      }
+    ) => {
+      return apiRequest("/admin/feature-flags", {
+        method: "POST",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify(data),
       });
-      return handleResponse<{ flags: string[] }>(response);
+    },
+
+    updateFeatureFlag: async (
+      token: string,
+      id: string,
+      data: { isEnabled?: boolean; description?: string }
+    ) => {
+      return apiRequest(`/admin/feature-flags/${id}`, {
+        method: "PATCH",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify(data),
+      });
+    },
+
+    getInviteCodes: async (token: string) => {
+      return apiRequest("/admin/invite-codes", { token });
+    },
+
+    createInviteCode: async (
+      token: string,
+      data: { maxUses?: number; expiresAt?: Date }
+    ) => {
+      return apiRequest("/admin/invite-codes", {
+        method: "POST",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify(data),
+      });
+    },
+
+    updateInviteCode: async (
+      token: string,
+      id: string,
+      data: { isActive: boolean }
+    ) => {
+      return apiRequest(`/admin/invite-codes/${id}`, {
+        method: "PATCH",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify(data),
+      });
+    },
+  },
+
+  track: {
+    get: async (id: string, token: string | null) => {
+      return apiRequest(`/track/${id}`, { token }) as Promise<Track>;
+    },
+
+    share: async (id: string, userIds: string[], token: string) => {
+      return apiRequest(`/track/${id}/share`, {
+        method: "POST",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify({ userIds }),
+      });
+    },
+
+    unshare: async (id: string, userIds: string[], token: string) => {
+      return apiRequest(`/track/${id}/share`, {
+        method: "DELETE",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify({ userIds }),
+      });
+    },
+
+    updateVisibility: async (id: string, isPublic: boolean, token: string) => {
+      return apiRequest(`/track/${id}/visibility`, {
+        method: "PATCH",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify({ isPublic }),
+      }) as Promise<Track>;
+    },
+
+    upload: async (formData: FormData, token: string) => {
+      return apiRequest("/track", {
+        method: "POST",
+        token,
+        body: formData,
+      }) as Promise<Track>;
+    },
+
+    delete: async (id: string, token: string) => {
+      return apiRequest(`/track/${id}`, {
+        method: "DELETE",
+        token,
+      });
+    },
+
+    // TODO: Move batchDelete to tracks?
+    batchDelete: async (ids: string[], token: string) => {
+      return apiRequest("/track/batch", {
+        method: "DELETE",
+        token,
+        contentType: "application/json",
+        body: JSON.stringify({ trackIds: ids }),
+      });
     },
   },
 
@@ -66,15 +214,9 @@ export const api = {
       if (params?.cursor) searchParams.set("cursor", params.cursor);
       if (params?.limit) searchParams.set("limit", params.limit.toString());
 
-      const response = await fetch(
-        `${API_BASE_URL}/tracks?${searchParams.toString()}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-      return handleResponse<PaginatedResponse<Track>>(response);
+      return apiRequest("/tracks", { token, searchParams }) as Promise<
+        PaginatedResponse<Track>
+      >;
     },
 
     listPublic: async (params?: PaginationParams) => {
@@ -82,10 +224,9 @@ export const api = {
       if (params?.cursor) searchParams.set("cursor", params.cursor);
       if (params?.limit) searchParams.set("limit", params.limit.toString());
 
-      const response = await fetch(
-        `${API_BASE_URL}/tracks/public?${searchParams.toString()}`
-      );
-      return handleResponse<PaginatedResponse<Track>>(response);
+      return apiRequest("/tracks/public", { searchParams }) as Promise<
+        PaginatedResponse<Track>
+      >;
     },
 
     listShared: async (token: string, params?: PaginationParams) => {
@@ -93,15 +234,9 @@ export const api = {
       if (params?.cursor) searchParams.set("cursor", params.cursor);
       if (params?.limit) searchParams.set("limit", params.limit.toString());
 
-      const response = await fetch(
-        `${API_BASE_URL}/tracks/shared?${searchParams.toString()}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-      return handleResponse<PaginatedResponse<Track>>(response);
+      return apiRequest("/tracks/shared", { token, searchParams }) as Promise<
+        PaginatedResponse<Track>
+      >;
     },
 
     listAvailable: async (token: string, params?: PaginationParams) => {
@@ -109,102 +244,52 @@ export const api = {
       if (params?.cursor) searchParams.set("cursor", params.cursor);
       if (params?.limit) searchParams.set("limit", params.limit.toString());
 
-      const response = await fetch(
-        `${API_BASE_URL}/tracks/available?${searchParams.toString()}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-      return handleResponse<PaginatedResponse<Track>>(response);
+      return apiRequest("/tracks/available", {
+        token,
+        searchParams,
+      }) as Promise<PaginatedResponse<Track>>;
     },
   },
 
-  track: {
-    get: async (token: string, id: string) => {
-      const response = await fetch(`${API_BASE_URL}/track/${id}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-      return handleResponse<Track>(response);
+  users: {
+    list: async (token: string) => {
+      return apiRequest("/auth/users", { token }) as Promise<User[]>;
     },
+  },
 
-    upload: async (formData: FormData, token: string) => {
-      const response = await fetch(`${API_BASE_URL}/track`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        body: formData,
-      });
-      return handleResponse<Track>(response);
-    },
-
-    delete: async (token: string, trackId: string) => {
-      const response = await fetch(`${API_BASE_URL}/track/${trackId}`, {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-      return handleResponse<void>(response);
-    },
-
-    batchDelete: async (token: string, trackIds: string[]) => {
-      const response = await fetch(`${API_BASE_URL}/track/batch`, {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ trackIds }),
-      });
-      return handleResponse<void>(response);
-    },
-
-    share: async (token: string, trackId: string, userIds: string[]) => {
-      const response = await fetch(`${API_BASE_URL}/track/${trackId}/share`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ userIds }),
-      });
-      return handleResponse<void>(response);
-    },
-
-    unshare: async (token: string, trackId: string, userIds: string[]) => {
-      const response = await fetch(`${API_BASE_URL}/track/${trackId}/share`, {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ userIds }),
-      });
-      return handleResponse<void>(response);
-    },
-
-    updateVisibility: async (
+  notifications: {
+    getNotifications: async (
       token: string,
-      trackId: string,
-      isPublic: boolean
+      {
+        limit,
+        offset,
+        includeRead,
+      }: { limit?: number; offset?: number; includeRead?: boolean } = {}
     ) => {
-      const response = await fetch(
-        `${API_BASE_URL}/track/${trackId}/visibility`,
-        {
-          method: "PATCH",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ isPublic }),
-        }
-      );
-      return handleResponse<Track>(response);
+      const params = new URLSearchParams();
+      if (limit) params.append("limit", limit.toString());
+      if (offset) params.append("offset", offset.toString());
+      if (includeRead) params.append("includeRead", "true");
+
+      return apiRequest(`/notifications?${params.toString()}`, { token });
+    },
+
+    getUnreadCount: async (token: string) => {
+      return apiRequest("/notifications/unread-count", { token });
+    },
+
+    markAsRead: async (token: string, notificationId: string) => {
+      return apiRequest(`/notifications/${notificationId}/read`, {
+        method: "POST",
+        token,
+      });
+    },
+
+    markAllAsRead: async (token: string) => {
+      return apiRequest("/notifications/mark-all-read", {
+        method: "POST",
+        token,
+      });
     },
   },
 };

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -25,7 +25,7 @@ const apiRequest = async (endpoint: string, options: FetchOptions = {}) => {
     headers.set("Content-Type", contentType);
   }
 
-  const url = new URL(`${API_URL}${endpoint}`);
+  const url = new URL(`${API_URL}${endpoint}`, window.location.origin);
   if (searchParams) {
     url.search = searchParams.toString();
   }

--- a/packages/frontend/src/components/ui/Tabs.tsx
+++ b/packages/frontend/src/components/ui/Tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "@/utils/cn";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-lg bg-gray-100 p-1 text-gray-500",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "data-[state=active]:bg-white data-[state=active]:text-gray-950 data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/packages/frontend/src/hooks/useAuthToken.ts
+++ b/packages/frontend/src/hooks/useAuthToken.ts
@@ -6,7 +6,9 @@ const appendTokenToUrlImpl = (url: string): string => {
 };
 
 export function useAuthToken() {
+  const token = getStoredToken();
   return {
+    token,
     getToken: getStoredToken,
     appendTokenToUrl: appendTokenToUrlImpl,
   };

--- a/packages/frontend/src/pages/BulkUploadTrack/components/UploadList.tsx
+++ b/packages/frontend/src/pages/BulkUploadTrack/components/UploadList.tsx
@@ -42,7 +42,7 @@ interface TrackListItemProps {
   onCoverArtDrop: (targetPath: string) => void;
 }
 
-function TrackListItem({
+function UploadListItem({
   match,
   index,
   currentUploadIndex,
@@ -177,7 +177,7 @@ function TrackListItem({
   );
 }
 
-interface TrackListProps {
+interface UploadListProps {
   matches: FileMatch[];
   currentUploadIndex: number;
   draggedCoverArt: DraggedCoverArt | null;
@@ -188,7 +188,7 @@ interface TrackListProps {
   onCoverArtDrop: (targetPath: string) => void;
 }
 
-export function TrackList({
+export function UploadList({
   matches,
   currentUploadIndex,
   draggedCoverArt,
@@ -197,7 +197,7 @@ export function TrackList({
   onCoverArtDragStart,
   onCoverArtDragEnd,
   onCoverArtDrop,
-}: TrackListProps) {
+}: UploadListProps) {
   if (matches.length === 0) return null;
 
   return (
@@ -207,7 +207,7 @@ export function TrackList({
       </h2>
       <ul className="space-y-4">
         {matches.map((match, i) => (
-          <TrackListItem
+          <UploadListItem
             key={match.path}
             match={match}
             index={i}

--- a/packages/frontend/src/pages/BulkUploadTrack/components/UploadProgress.tsx
+++ b/packages/frontend/src/pages/BulkUploadTrack/components/UploadProgress.tsx
@@ -8,7 +8,6 @@ interface UploadProgressProps {
   error?: string;
   onClearAll: () => void;
   onAddMoreFiles: () => void;
-  onUpload: () => void;
 }
 
 export function UploadProgress({
@@ -19,7 +18,6 @@ export function UploadProgress({
   error,
   onClearAll,
   onAddMoreFiles,
-  onUpload,
 }: UploadProgressProps) {
   const pendingUploads = matches.filter((m) => !m.uploaded);
   const progress =
@@ -74,7 +72,6 @@ export function UploadProgress({
             isUploadInProgress ||
             pendingUploads.length === 0
           }
-          onClick={onUpload}
         >
           {isUploadInProgress
             ? `Uploading (${currentUploadIndex + 1}/${pendingUploads.length})`

--- a/packages/frontend/src/pages/BulkUploadTrack/index.tsx
+++ b/packages/frontend/src/pages/BulkUploadTrack/index.tsx
@@ -3,7 +3,7 @@ import { FormInput } from "@/components/ui/FormInput";
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { useFileProcessing } from "./hooks/useFileProcessing";
 import { DropZone } from "./components/DropZone";
-import { TrackList } from "./components/TrackList";
+import { UploadList } from "./components/UploadList";
 import { UnmatchedArt } from "./components/UnmatchedArt";
 import { UploadProgress } from "./components/UploadProgress";
 
@@ -67,7 +67,7 @@ export function BulkUploadTrack() {
           disabled={isUploadInProgress}
         />
 
-        <TrackList
+        <UploadList
           matches={state.matches}
           currentUploadIndex={state.currentUploadIndex}
           draggedCoverArt={draggedCoverArt}

--- a/packages/frontend/src/pages/BulkUploadTrack/index.tsx
+++ b/packages/frontend/src/pages/BulkUploadTrack/index.tsx
@@ -106,7 +106,6 @@ export function BulkUploadTrack() {
               input.click();
             }
           }}
-          onUpload={() => handleSubmit()}
         />
       </form>
     </div>

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -22,7 +22,7 @@ function PublicTracks() {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-6">Public Tracks</h1>
-      <TrackList tracks={publicTracks || []} />
+      <TrackList tracks={publicTracks?.items || []} />
     </div>
   );
 }
@@ -45,7 +45,7 @@ function AvailableTracks({ token }: { token: string }) {
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-6">Available Tracks</h1>
-      <TrackList tracks={availableTracks || []} />
+      <TrackList tracks={availableTracks?.items || []} />
     </div>
   );
 }

--- a/packages/frontend/src/pages/MyTracks.tsx
+++ b/packages/frontend/src/pages/MyTracks.tsx
@@ -29,7 +29,7 @@ export default function MyTracks() {
     enabled: !!token,
     getNextPageParam: (lastPage: PaginatedResponse<Track>) =>
       lastPage.metadata.nextCursor,
-    initialPageParam: null as string | null,
+    initialPageParam: undefined as string | undefined,
   });
 
   const {
@@ -46,7 +46,7 @@ export default function MyTracks() {
     enabled: !!token,
     getNextPageParam: (lastPage: PaginatedResponse<Track>) =>
       lastPage.metadata.nextCursor,
-    initialPageParam: null as string | null,
+    initialPageParam: undefined as string | undefined,
   });
 
   const deleteTrackMutation = useMutation({

--- a/packages/frontend/src/pages/MyTracks.tsx
+++ b/packages/frontend/src/pages/MyTracks.tsx
@@ -1,58 +1,61 @@
+import { useAuthToken } from "@/hooks/useAuthToken";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { TrackSection } from "@/components/track-list/TrackList";
+import { ErrorState } from "@/components/ui/ErrorState";
 import { useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAuthToken } from "../hooks/useAuthToken";
-import { api } from "../api/client";
-import { TrackSection } from "../components/track-list/TrackList";
-import { BatchActionsBar } from "../components/BatchActionsBar";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/Tabs";
+import { Track, PaginatedResponse } from "@/types";
 
-export function MyTracks() {
-  const { getToken } = useAuthToken();
-  const token = getToken();
-  const queryClient = useQueryClient();
+export default function MyTracks() {
+  const { token } = useAuthToken();
   const [selectedTracks, setSelectedTracks] = useState<Set<string>>(new Set());
+  const queryClient = useQueryClient();
 
   const {
-    data: userTracks,
+    data: userTracksData,
     isLoading: isLoadingUserTracks,
     error: userTracksError,
-  } = useQuery({
+    fetchNextPage: fetchNextUserTracks,
+    hasNextPage: hasNextUserTracksPage,
+    isFetchingNextPage: isFetchingNextUserTracksPage,
+  } = useInfiniteQuery({
     queryKey: ["tracks", token],
-    queryFn: async () => (token ? api.tracks.list(token) : undefined),
+    queryFn: ({ pageParam }) => api.tracks.list(token!, { cursor: pageParam }),
     enabled: !!token,
+    getNextPageParam: (lastPage: PaginatedResponse<Track>) =>
+      lastPage.metadata.nextCursor,
+    initialPageParam: null as string | null,
   });
 
   const {
-    data: sharedTracks,
+    data: sharedTracksData,
     isLoading: isLoadingSharedTracks,
     error: sharedTracksError,
-  } = useQuery({
+    fetchNextPage: fetchNextSharedTracks,
+    hasNextPage: hasNextSharedTracksPage,
+    isFetchingNextPage: isFetchingNextSharedTracksPage,
+  } = useInfiniteQuery({
     queryKey: ["shared-tracks", token],
-    queryFn: async () => (token ? api.tracks.listShared(token) : undefined),
+    queryFn: ({ pageParam }) =>
+      api.tracks.listShared(token!, { cursor: pageParam }),
     enabled: !!token,
+    getNextPageParam: (lastPage: PaginatedResponse<Track>) =>
+      lastPage.metadata.nextCursor,
+    initialPageParam: null as string | null,
   });
 
   const deleteTrackMutation = useMutation({
-    mutationFn: (trackId: string) => {
-      if (!token) {
-        throw new Error("No token available");
-      }
-      return api.track.delete(trackId, token);
+    mutationFn: async (trackId: string) => {
+      if (!token) return;
+      await api.track.delete(token, trackId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tracks"] });
-    },
-  });
-
-  const deleteTracksMutation = useMutation({
-    mutationFn: (trackIds: string[]) => {
-      if (!token) {
-        throw new Error("No token available");
-      }
-      return api.track.batchDelete(trackIds, token);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["tracks"] });
-      setSelectedTracks(new Set());
     },
   });
 
@@ -68,45 +71,54 @@ export function MyTracks() {
     });
   };
 
-  const handleDeleteTracks = () => {
-    if (selectedTracks.size > 0) {
-      deleteTracksMutation.mutate(Array.from(selectedTracks));
-    }
-  };
+  if (!token) {
+    return <ErrorState message="Please log in to view your tracks" />;
+  }
 
-  const handleCancelSelection = () => {
-    setSelectedTracks(new Set());
-  };
+  const userTracks = userTracksData?.pages.flatMap((page) => page.items) || [];
+  const sharedTracks =
+    sharedTracksData?.pages.flatMap((page) => page.items) || [];
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-8">Your Tracks</h1>
+      <Tabs defaultValue="my-tracks">
+        <TabsList className="mb-8">
+          <TabsTrigger value="my-tracks">My Tracks</TabsTrigger>
+          <TabsTrigger value="shared">Shared With Me</TabsTrigger>
+        </TabsList>
 
-      <TrackSection
-        title=""
-        tracks={userTracks}
-        isLoading={isLoadingUserTracks}
-        error={userTracksError}
-        selectable={true}
-        selectedTracks={selectedTracks}
-        onTrackSelect={handleTrackSelect}
-        onDeleteTrack={deleteTrackMutation.mutate}
-      />
+        <TabsContent value="my-tracks">
+          <TrackSection
+            title=""
+            tracks={userTracks}
+            isLoading={isLoadingUserTracks}
+            error={userTracksError}
+            selectable={true}
+            selectedTracks={selectedTracks}
+            onTrackSelect={handleTrackSelect}
+            onDeleteTrack={deleteTrackMutation.mutate}
+            onLoadMore={
+              hasNextUserTracksPage ? () => fetchNextUserTracks() : undefined
+            }
+            isLoadingMore={isFetchingNextUserTracksPage}
+          />
+        </TabsContent>
 
-      <TrackSection
-        title="Shared With You"
-        tracks={sharedTracks}
-        isLoading={isLoadingSharedTracks}
-        error={sharedTracksError}
-      />
-
-      {selectedTracks.size > 0 && (
-        <BatchActionsBar
-          selectedCount={selectedTracks.size}
-          onDelete={handleDeleteTracks}
-          onCancelSelection={handleCancelSelection}
-        />
-      )}
+        <TabsContent value="shared">
+          <TrackSection
+            title=""
+            tracks={sharedTracks}
+            isLoading={isLoadingSharedTracks}
+            error={sharedTracksError}
+            onLoadMore={
+              hasNextSharedTracksPage
+                ? () => fetchNextSharedTracks()
+                : undefined
+            }
+            isLoadingMore={isFetchingNextSharedTracksPage}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/packages/frontend/src/pages/MyTracks.tsx
+++ b/packages/frontend/src/pages/MyTracks.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/Tabs";
 import { Track, PaginatedResponse } from "@/types";
 
-export default function MyTracks() {
+export function MyTracks() {
   const { token } = useAuthToken();
   const [selectedTracks, setSelectedTracks] = useState<Set<string>>(new Set());
   const queryClient = useQueryClient();

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -1,42 +1,5 @@
-export interface User {
-  id: string;
-  email: string;
-  username: string;
-}
-
-export interface TrackShare {
-  userId: string;
-  user: User;
-}
-
-export interface Track {
-  id: string;
-  title: string;
-  artist: string;
-  originalFormat: string;
-  originalUrl: string;
-  fullTrackUrl: string;
-  fullTrackMp3Url: string;
-  waveformData: number[];
-  coverArt?: string | null;
-  metadata?: Record<string, unknown>;
-  isPublic: boolean;
-  userId: string;
-  user: User;
-  sharedWith: TrackShare[];
-  components: Component[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface Component {
-  id: string;
-  name: string;
-  type: string;
-  wavUrl: string;
-  mp3Url: string;
-  waveformData: number[];
-  trackId: string;
-  createdAt: string;
-  updatedAt: string;
-}
+export type {
+  Track,
+  PaginatedResponse,
+  PaginationParams,
+} from "@wavtopia/core-storage";

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -2,4 +2,5 @@ export type {
   Track,
   PaginatedResponse,
   PaginationParams,
+  User,
 } from "@wavtopia/core-storage";

--- a/pnpm-lock.arm64.yaml
+++ b/pnpm-lock.arm64.yaml
@@ -144,6 +144,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.62.14
         version: 5.64.1(react@18.3.1)
@@ -803,6 +806,19 @@ packages:
 
   '@radix-ui/react-switch@1.1.2':
     resolution: {integrity: sha512-zGukiWHjEdBCRyXvKR6iXAQG6qXm2esuAD6kDOi9Cn+1X6ev3ASo4+CsYaD6Fov9r/AQFekqnD/7+V0Cs6/98g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.2':
+    resolution: {integrity: sha512-9u/tQJMcC2aGq7KXpGivMm1mgq7oRJKXphDwdypPd/j21j/2znamPU8WkXgnhUaTrSFNIt8XhOyCAupg8/GbwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3315,6 +3331,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-tabs@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
This PR adds cursor-based pagination support for track listings to improve performance and scalability. Key changes include:

- Add cursor-based pagination helper function in backend tracks routes
- Create database index on tracks(created_at, id) for efficient pagination queries
- Add pagination types and cursor encoding/decoding utilities
- Update frontend track list components to support infinite scrolling
- Modify API client to handle paginated responses
- Add loading states for pagination UI

The implementation uses a cursor-based approach with createdAt + id as the pagination key, which ensures consistent ordering and handles concurrent updates gracefully. The default page size is 20 items.