### PR TITLE
Add track duration and improve minio debugging

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -253,3 +253,67 @@ When adding new features or fixing bugs:
 2. Document error cases
 3. Update this debugging guide
 4. Add relevant tests
+
+## MinIO Debugging
+
+To list all files in the MinIO bucket when using Docker, use this command pattern:
+
+```bash
+docker run --rm --network wavtopia_wavtopia-net -it --entrypoint=/bin/sh minio/mc -c "mc alias set myminio http://minio:9000 USER PASS && mc ls --recursive myminio/wavtopia"
+```
+
+Note: Replace USER and PASS with your MinIO credentials.
+
+This command:
+
+1. Uses the MinIO client (mc) Docker image
+2. Sets up a temporary alias for the MinIO server
+3. Lists all files recursively in the specified bucket
+4. Works within the Docker network context
+
+### Additional MinIO Debugging Commands
+
+1. **Check Bucket Size**
+
+   ```bash
+   docker run --rm --network wavtopia_wavtopia-net -it --entrypoint=/bin/sh minio/mc -c "mc alias set myminio http://minio:9000 USER PASS && mc du myminio/wavtopia"
+   ```
+
+2. **Verify File Existence**
+
+   ```bash
+   docker run --rm --network wavtopia_wavtopia-net -it --entrypoint=/bin/sh minio/mc -c "mc alias set myminio http://minio:9000 USER PASS && mc stat myminio/wavtopia/path/to/file"
+   ```
+
+3. **List Bucket Policies**
+
+   ```bash
+   docker run --rm --network wavtopia_wavtopia-net -it --entrypoint=/bin/sh minio/mc -c "mc alias set myminio http://minio:9000 USER PASS && mc policy get myminio/wavtopia"
+   ```
+
+4. **Monitor MinIO Events**
+   ```bash
+   docker run --rm --network wavtopia_wavtopia-net -it --entrypoint=/bin/sh minio/mc -c "mc alias set myminio http://minio:9000 USER PASS && mc watch myminio/wavtopia"
+   ```
+
+### Common MinIO Issues
+
+1. **File Not Found Issues**
+
+   - Check if the file path includes the bucket name
+   - Verify the correct bucket is being accessed
+   - Ensure file paths use forward slashes (/)
+   - Check file permissions
+
+2. **Connection Issues**
+
+   - Verify MinIO service is running: `docker compose ps`
+   - Check network connectivity within Docker
+   - Verify correct port mapping
+   - Ensure credentials are correct
+
+3. **Performance Issues**
+   - Monitor disk usage: `docker system df`
+   - Check MinIO logs: `docker compose logs minio`
+   - Verify network bandwidth between services
+   - Consider using MinIO's built-in monitoring

--- a/packages/backend/src/routes/tracks.ts
+++ b/packages/backend/src/routes/tracks.ts
@@ -10,7 +10,7 @@ import {
 } from "@wavtopia/core-storage";
 
 const router = Router();
-const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 6;
 
 // Helper function to handle cursor-based pagination
 async function getPaginatedTracks<I extends Prisma.TrackInclude>(

--- a/packages/core-storage/prisma/migrations/20250117024422_add_track_duration/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250117024422_add_track_duration/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "tracks" ADD COLUMN "duration" DOUBLE PRECISION;

--- a/packages/core-storage/prisma/migrations/20250118022454_add_duration_to_component/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250118022454_add_duration_to_component/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "components" ADD COLUMN     "duration" DOUBLE PRECISION;

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Track {
   fullTrackUrl    String?      @map("full_track_url")
   fullTrackMp3Url String?      @map("full_track_mp3_url")
   waveformData    Float[]      @map("waveform_data")
+  duration        Float?       @map("duration")
   coverArt        String?      @map("cover_art")
   metadata        Json?
   isPublic        Boolean      @default(false) @map("is_public")

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Component {
   wavUrl       String   @map("wav_url")
   mp3Url       String   @map("mp3_url")
   waveformData Float[]  @map("waveform_data")
+  duration     Float?   @map("duration")
   trackId      String   @map("track_id")
   track        Track    @relation(fields: [trackId], references: [id])
   createdAt    DateTime @default(now()) @map("created_at")

--- a/packages/frontend/src/components/track-details/FullTrackSection.tsx
+++ b/packages/frontend/src/components/track-details/FullTrackSection.tsx
@@ -18,6 +18,7 @@ export function FullTrackSection({ track }: FullTrackSectionProps) {
         ) : (
           <SyncedWaveform
             waveformData={track.waveformData}
+            duration={track.duration ?? undefined}
             height={96}
             audioUrl={getAudioUrl(`/api/track/${track.id}/full.mp3`)}
             isFullTrack={true}

--- a/packages/frontend/src/components/track-details/TrackComponent.tsx
+++ b/packages/frontend/src/components/track-details/TrackComponent.tsx
@@ -37,6 +37,7 @@ export function TrackComponent({
       </div>
       <SyncedWaveform
         waveformData={component.waveformData}
+        duration={component.duration ?? undefined}
         height={isGridView ? 48 : 64}
         color="#4b5563"
         progressColor="#6366f1"

--- a/packages/frontend/src/components/track-list/TrackList.tsx
+++ b/packages/frontend/src/components/track-list/TrackList.tsx
@@ -202,6 +202,7 @@ export function TrackList({
             ) : (
               <TrackListWaveform
                 waveformData={track.waveformData}
+                duration={track.duration ?? undefined}
                 audioUrl={appendTokenToUrl(`/api/track/${track.id}/full.mp3`)}
                 height={48}
                 color="#4b5563"

--- a/packages/frontend/src/components/waveform/SyncedWaveform.tsx
+++ b/packages/frontend/src/components/waveform/SyncedWaveform.tsx
@@ -4,6 +4,7 @@ import { WaveformDisplay } from "./WaveformDisplay";
 interface SyncedWaveformProps {
   waveformData: number[];
   audioUrl: string;
+  duration?: number;
   height?: number;
   color?: string;
   progressColor?: string;
@@ -13,6 +14,7 @@ interface SyncedWaveformProps {
 export function SyncedWaveform({
   waveformData,
   audioUrl,
+  duration,
   height = 128,
   color = "#1f2937",
   progressColor = "#4f46e5",
@@ -25,6 +27,7 @@ export function SyncedWaveform({
       context={playbackContext}
       waveformData={waveformData}
       audioUrl={audioUrl}
+      duration={duration}
       height={height}
       color={color}
       progressColor={progressColor}

--- a/packages/frontend/src/components/waveform/TrackListWaveform.tsx
+++ b/packages/frontend/src/components/waveform/TrackListWaveform.tsx
@@ -4,6 +4,7 @@ import { WaveformDisplay } from "./WaveformDisplay";
 interface TrackListWaveformProps {
   waveformData: number[];
   audioUrl: string;
+  duration?: number;
   height?: number;
   color?: string;
   progressColor?: string;
@@ -12,6 +13,7 @@ interface TrackListWaveformProps {
 export function TrackListWaveform({
   waveformData,
   audioUrl,
+  duration,
   height = 48,
   color = "#4b5563",
   progressColor = "#6366f1",
@@ -23,6 +25,7 @@ export function TrackListWaveform({
       context={trackListContext}
       waveformData={waveformData}
       audioUrl={audioUrl}
+      duration={duration}
       height={height}
       color={color}
       progressColor={progressColor}

--- a/packages/frontend/src/components/waveform/WaveformDisplay.tsx
+++ b/packages/frontend/src/components/waveform/WaveformDisplay.tsx
@@ -7,6 +7,7 @@ interface WaveformDisplayProps {
   context: TrackListPlaybackContextType | SyncedPlaybackContextType;
   waveformData: number[];
   audioUrl: string;
+  duration?: number;
   height?: number;
   color?: string;
   progressColor?: string;
@@ -17,6 +18,7 @@ export function WaveformDisplay({
   context,
   waveformData,
   audioUrl,
+  duration,
   height = 128,
   color = "#1f2937",
   progressColor = "#4f46e5",
@@ -114,11 +116,12 @@ export function WaveformDisplay({
       minPxPerSec: 0,
       backend: "WebAudio" as const,
       peaks: [new Float32Array(waveformData)],
+      duration,
       url: audioUrl,
       autoplay: false,
     }),
     // Only include dependencies that should cause a full recreation
-    [audioUrl]
+    [audioUrl, duration, waveformData]
   );
 
   // Initialize WaveSurfer instance

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -12,6 +12,7 @@ export interface Track {
   coverArt: string | null;
   originalUrl: string | null;
   waveformData: number[];
+  duration?: number;
   isPublic: boolean;
   userId: string;
   user: User;
@@ -23,7 +24,13 @@ export interface TrackComponent {
   id: string;
   name: string;
   type: string;
+  wavUrl: string;
+  mp3Url: string;
   waveformData: number[];
+  duration?: number;
+  trackId: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface TrackShare {

--- a/packages/media/src/services/queue.ts
+++ b/packages/media/src/services/queue.ts
@@ -148,6 +148,7 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
           wavUrl,
           mp3Url,
           waveformData: waveformResult.peaks,
+          duration: waveformResult.duration,
         };
       })
     );


### PR DESCRIPTION
This PR adds duration tracking for audio tracks and components, along with comprehensive MinIO debugging documentation.

Changes:
- Add duration field to tracks and components tables
- Update waveform generation to calculate and store audio duration
- Add duration prop to waveform display components
- Add MinIO debugging guide with common commands and troubleshooting tips
- Reduce default page size for tracks from 20 to 6

Testing:
- Verify duration is correctly calculated and stored for new uploads
- Confirm duration is displayed properly in waveform components
- Test MinIO debugging commands in Docker environment