### PR TITLE
Add flac support and make wav conversion on-demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ npm-debug.log*
 coverage
 
 # Audio files
+*.flac
 *.wav
 *.xm
 uploads/ 

--- a/packages/backend/src/middleware/trackAccess.ts
+++ b/packages/backend/src/middleware/trackAccess.ts
@@ -72,7 +72,7 @@ export function requireTrackAccess(options: { allowPublic?: boolean } = {}) {
           artist: track.artist,
           coverArt: track.coverArt,
           isPublic: track.isPublic,
-          fullTrackUrl: track.fullTrackUrl,
+          fullTrackWavUrl: track.fullTrackWavUrl,
           fullTrackMp3Url: track.fullTrackMp3Url,
           waveformData: track.waveformData,
           components: track.components,

--- a/packages/backend/src/routes/track.ts
+++ b/packages/backend/src/routes/track.ts
@@ -211,7 +211,17 @@ router.get(
       }
 
       const format = req.params.format.toLowerCase();
-      const filePath = format === "mp3" ? component.mp3Url : component.wavUrl;
+
+      let filePath: string;
+      if (format === "mp3") {
+        filePath = component.mp3Url;
+      } else if (format === "wav") {
+        filePath = component.wavUrl;
+      } else if (format === "flac") {
+        filePath = component.flacUrl;
+      } else {
+        throw new AppError(400, "Invalid format");
+      }
 
       // Stream the file directly from MinIO
       const fileStream = await getObject(filePath);
@@ -235,8 +245,17 @@ router.get(
     try {
       const track = (req as any).track; // TODO: Fix this `any`
       const format = req.params.format.toLowerCase();
-      const filePath =
-        format === "mp3" ? track.fullTrackMp3Url : track.fullTrackUrl;
+
+      let filePath: string;
+      if (format === "mp3") {
+        filePath = track.fullTrackMp3Url;
+      } else if (format === "wav") {
+        filePath = track.fullTrackUrl;
+      } else if (format === "flac") {
+        filePath = track.fullTrackFlacUrl;
+      } else {
+        throw new AppError(400, "Invalid format");
+      }
 
       // Stream the file directly from MinIO
       const fileStream = await getObject(filePath);

--- a/packages/backend/src/routes/track.ts
+++ b/packages/backend/src/routes/track.ts
@@ -634,7 +634,7 @@ router.post(
   }
 );
 
-// Get WAV conversion status
+// Get track WAV conversion status
 router.get(
   "/:id/wav-status",
   authenticateTrackAccess,
@@ -647,7 +647,30 @@ router.get(
       }
 
       const response = await fetch(
-        mediaServiceUrl + `/api/media/wav-status/${req.params.id}`
+        `${mediaServiceUrl}/api/media/wav-status/${req.params.id}`
+      );
+      const data = await response.json();
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// Get component WAV conversion status
+router.get(
+  "/:id/component/:componentId/wav-status",
+  authenticateTrackAccess,
+  async (req, res, next) => {
+    try {
+      const mediaServiceUrl = config.services.mediaServiceUrl;
+
+      if (!mediaServiceUrl) {
+        throw new AppError(500, "Media service URL not configured");
+      }
+
+      const response = await fetch(
+        `${mediaServiceUrl}/api/media/component/${req.params.componentId}/wav-status`
       );
       const data = await response.json();
       res.json(data);

--- a/packages/backend/src/routes/track.ts
+++ b/packages/backend/src/routes/track.ts
@@ -133,7 +133,7 @@ const authenticateTrackAccess: RequestHandler = async (
         artist: reqTrack.artist,
         coverArt: reqTrack.coverArt,
         isPublic: reqTrack.isPublic,
-        fullTrackUrl: reqTrack.fullTrackUrl,
+        fullTrackWavUrl: reqTrack.fullTrackWavUrl,
         fullTrackMp3Url: reqTrack.fullTrackMp3Url,
         originalFormat: reqTrack.originalFormat,
         waveformData: reqTrack.waveformData,
@@ -250,7 +250,7 @@ router.get(
       if (format === "mp3") {
         filePath = track.fullTrackMp3Url;
       } else if (format === "wav") {
-        filePath = track.fullTrackUrl;
+        filePath = track.fullTrackWavUrl;
       } else if (format === "flac") {
         filePath = track.fullTrackFlacUrl;
       } else {

--- a/packages/backend/src/routes/track.ts
+++ b/packages/backend/src/routes/track.ts
@@ -601,4 +601,60 @@ router.patch("/:id/visibility", async (req: Request, res: Response, next) => {
   }
 });
 
+// Request WAV conversion
+router.post(
+  "/:id/convert-wav",
+  authenticateTrackAccess,
+  async (req, res, next) => {
+    try {
+      const { type, componentId } = req.body;
+      const mediaServiceUrl = config.services.mediaServiceUrl;
+
+      if (!mediaServiceUrl) {
+        throw new AppError(500, "Media service URL not configured");
+      }
+
+      const response = await fetch(mediaServiceUrl + "/api/media/convert-wav", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          trackId: req.params.id,
+          type,
+          componentId,
+        }),
+      });
+
+      const data = await response.json();
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+// Get WAV conversion status
+router.get(
+  "/:id/wav-status",
+  authenticateTrackAccess,
+  async (req, res, next) => {
+    try {
+      const mediaServiceUrl = config.services.mediaServiceUrl;
+
+      if (!mediaServiceUrl) {
+        throw new AppError(500, "Media service URL not configured");
+      }
+
+      const response = await fetch(
+        mediaServiceUrl + `/api/media/wav-status/${req.params.id}`
+      );
+      const data = await response.json();
+      res.json(data);
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
 export { router as trackRoutes };

--- a/packages/backend/src/services/track.ts
+++ b/packages/backend/src/services/track.ts
@@ -7,15 +7,15 @@ import { deleteFile } from "./storage";
  */
 async function deleteTrackFiles(track: {
   originalUrl: string;
-  fullTrackUrl?: string | null;
+  fullTrackWavUrl?: string | null;
   fullTrackMp3Url?: string | null;
   coverArt?: string | null;
   components: { wavUrl: string; mp3Url: string }[];
 }) {
   await deleteFile(track.originalUrl);
 
-  if (track.fullTrackUrl) {
-    await deleteFile(track.fullTrackUrl);
+  if (track.fullTrackWavUrl) {
+    await deleteFile(track.fullTrackWavUrl);
   }
 
   if (track.fullTrackMp3Url) {

--- a/packages/core-storage/prisma/migrations/20250126024637_add_flac_urls/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250126024637_add_flac_urls/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "components" ADD COLUMN     "flac_url" TEXT;
+
+-- AlterTable
+ALTER TABLE "tracks" ADD COLUMN     "full_track_flac_url" TEXT;

--- a/packages/core-storage/prisma/migrations/20250126025000_rename_full_track_url_to_wav/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250126025000_rename_full_track_url_to_wav/migration.sql
@@ -1,0 +1,2 @@
+-- Rename column
+ALTER TABLE "tracks" RENAME COLUMN "full_track_url" TO "full_track_wav_url"; 

--- a/packages/core-storage/prisma/migrations/20250126075031_add_wav_conversion_status/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250126075031_add_wav_conversion_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "WavConversionStatus" AS ENUM ('NOT_STARTED', 'IN_PROGRESS', 'COMPLETED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "tracks" ADD COLUMN     "wavConversionStatus" "WavConversionStatus" NOT NULL DEFAULT 'NOT_STARTED';

--- a/packages/core-storage/prisma/migrations/20250126075031_add_wav_conversion_status/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250126075031_add_wav_conversion_status/migration.sql
@@ -2,4 +2,4 @@
 CREATE TYPE "WavConversionStatus" AS ENUM ('NOT_STARTED', 'IN_PROGRESS', 'COMPLETED', 'FAILED');
 
 -- AlterTable
-ALTER TABLE "tracks" ADD COLUMN     "wavConversionStatus" "WavConversionStatus" NOT NULL DEFAULT 'NOT_STARTED';
+ALTER TABLE "tracks" ADD COLUMN     "wav_conversion_status" "WavConversionStatus" NOT NULL DEFAULT 'NOT_STARTED';

--- a/packages/core-storage/prisma/migrations/20250126100158_add_component_wav_conversion_status/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250126100158_add_component_wav_conversion_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "components" ADD COLUMN     "wav_conversion_status" "WavConversionStatus" NOT NULL DEFAULT 'NOT_STARTED';

--- a/packages/core-storage/prisma/migrations/20250126111607_make_wav_url_optional/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250126111607_make_wav_url_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "components" ALTER COLUMN "wav_url" DROP NOT NULL;

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -53,7 +53,7 @@ model Track {
   sharedWith       TrackShare[] @relation("SharedTracks")
   createdAt        DateTime     @default(now()) @map("created_at")
   updatedAt        DateTime     @updatedAt @map("updated_at")
-  wavConversionStatus WavConversionStatus @default(NOT_STARTED)
+  wavConversionStatus WavConversionStatus @default(NOT_STARTED) @map("wav_conversion_status")
 
   @@index([createdAt, id])
   @@index([title, id])

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -34,25 +34,25 @@ enum Role {
 // TODO: The Url suffixes should be removed/replaced, as the values stored are not URLs (with
 // the exception of originalUrl, which is a file:// URL until the track is converted).
 model Track {
-  id              String       @id @default(uuid())
-  title           String
-  artist          String
-  originalFormat  String       @map("original_format")
-  originalUrl     String       @map("original_url")
-  fullTrackUrl    String?      @map("full_track_url")
-  fullTrackMp3Url String?      @map("full_track_mp3_url")
-  fullTrackFlacUrl String?     @map("full_track_flac_url")
-  waveformData    Float[]      @map("waveform_data")
-  duration        Float?       @map("duration")
-  coverArt        String?      @map("cover_art")
-  metadata        Json?
-  isPublic        Boolean      @default(false) @map("is_public")
-  components      Component[]
-  userId          String       @map("user_id")
-  user            User         @relation(fields: [userId], references: [id])
-  sharedWith      TrackShare[] @relation("SharedTracks")
-  createdAt       DateTime     @default(now()) @map("created_at")
-  updatedAt       DateTime     @updatedAt @map("updated_at")
+  id               String       @id @default(uuid())
+  title            String
+  artist           String
+  originalFormat   String       @map("original_format")
+  originalUrl      String       @map("original_url")
+  fullTrackWavUrl  String?      @map("full_track_wav_url")
+  fullTrackMp3Url  String?      @map("full_track_mp3_url")
+  fullTrackFlacUrl String?      @map("full_track_flac_url")
+  waveformData     Float[]      @map("waveform_data")
+  duration         Float?       @map("duration")
+  coverArt         String?      @map("cover_art")
+  metadata         Json?
+  isPublic         Boolean      @default(false) @map("is_public")
+  components       Component[]
+  userId           String       @map("user_id")
+  user             User         @relation(fields: [userId], references: [id])
+  sharedWith       TrackShare[] @relation("SharedTracks")
+  createdAt        DateTime     @default(now()) @map("created_at")
+  updatedAt        DateTime     @updatedAt @map("updated_at")
 
   @@index([createdAt, id])
   @@index([title, id])

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -79,7 +79,7 @@ model Component {
   id           String   @id @default(uuid())
   name         String
   type         String
-  wavUrl       String   @map("wav_url")
+  wavUrl       String?  @map("wav_url")
   mp3Url       String   @map("mp3_url")
   flacUrl      String?  @map("flac_url")
   waveformData Float[]  @map("waveform_data")

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Track {
   originalUrl     String       @map("original_url")
   fullTrackUrl    String?      @map("full_track_url")
   fullTrackMp3Url String?      @map("full_track_mp3_url")
+  fullTrackFlacUrl String?     @map("full_track_flac_url")
   waveformData    Float[]      @map("waveform_data")
   duration        Float?       @map("duration")
   coverArt        String?      @map("cover_art")
@@ -79,6 +80,7 @@ model Component {
   type         String
   wavUrl       String   @map("wav_url")
   mp3Url       String   @map("mp3_url")
+  flacUrl      String?  @map("flac_url")
   waveformData Float[]  @map("waveform_data")
   duration     Float?   @map("duration")
   trackId      String   @map("track_id")

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -86,6 +86,7 @@ model Component {
   duration     Float?   @map("duration")
   trackId      String   @map("track_id")
   track        Track    @relation(fields: [trackId], references: [id])
+  wavConversionStatus WavConversionStatus @default(NOT_STARTED) @map("wav_conversion_status")
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Track {
   sharedWith       TrackShare[] @relation("SharedTracks")
   createdAt        DateTime     @default(now()) @map("created_at")
   updatedAt        DateTime     @updatedAt @map("updated_at")
+  wavConversionStatus WavConversionStatus @default(NOT_STARTED)
 
   @@index([createdAt, id])
   @@index([title, id])
@@ -171,4 +172,11 @@ model Notification {
   updatedAt DateTime        @updatedAt @map("updated_at")
 
   @@map("notifications")
+}
+
+enum WavConversionStatus {
+  NOT_STARTED
+  IN_PROGRESS
+  COMPLETED
+  FAILED
 }

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -22,6 +22,7 @@ export {
   FeatureFlag,
   Notification,
   NotificationType,
+  WavConversionStatus,
 } from ".prisma/client";
 
 export {

--- a/packages/core-storage/types/index.d.ts
+++ b/packages/core-storage/types/index.d.ts
@@ -2,6 +2,6 @@ export { StorageService, type StorageFile } from "./services/storage";
 export { PrismaService } from "./services/prisma";
 export { deleteLocalFile, ensureDirectoryExists, normalizeFilePath, } from "./services/local-storage";
 export { config, type StorageConfig, type DatabaseConfig, type RedisConfig, type SharedConfig, } from "./config";
-export { Prisma, User, Role, InviteCode, FeatureFlag, Notification, NotificationType, } from ".prisma/client";
+export { Prisma, User, Role, InviteCode, FeatureFlag, Notification, NotificationType, WavConversionStatus, } from ".prisma/client";
 export { type Track, type PaginatedResponse, type PaginationParams, encodeCursor, decodeCursor, } from "./types";
 export * from "./auth";

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { RequestEarlyAccess } from "@/pages/RequestEarlyAccess";
 import Notifications from "@/pages/Notifications";
 import { BulkUploadTrack } from "./pages/BulkUploadTrack";
 import { useInitializeFeatureFlags } from "./hooks/useFeatureFlags";
+import { NotificationsProvider } from "./contexts/NotificationsContext";
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuth();
@@ -95,7 +96,9 @@ export default function App() {
   return (
     <Router>
       <AuthProvider>
-        <AppRoutes />
+        <NotificationsProvider>
+          <AppRoutes />
+        </NotificationsProvider>
       </AuthProvider>
     </Router>
   );

--- a/packages/frontend/src/components/track-details/ComponentsSection.tsx
+++ b/packages/frontend/src/components/track-details/ComponentsSection.tsx
@@ -33,7 +33,7 @@ export function ComponentsSection({
           <TrackComponent
             key={component.id}
             component={component}
-            trackId={track.id}
+            track={track}
             isGridView={viewMode === "grid"}
           />
         ))}

--- a/packages/frontend/src/components/track-details/DownloadLink.tsx
+++ b/packages/frontend/src/components/track-details/DownloadLink.tsx
@@ -56,6 +56,12 @@ export function ComponentDownloadButtons({
       >
         MP3
       </DownloadLink>
+      <DownloadLink
+        href={`/api/track/${trackId}/component/${componentId}.flac`}
+        small
+      >
+        FLAC
+      </DownloadLink>
     </div>
   );
 }

--- a/packages/frontend/src/components/track-details/DownloadLink.tsx
+++ b/packages/frontend/src/components/track-details/DownloadLink.tsx
@@ -134,16 +134,16 @@ export function ComponentDownloadButtons({
         WAV
       </DownloadLinkWav>
       <DownloadLink
-        href={`/api/track/${trackId}/component/${componentId}.mp3`}
-        small
-      >
-        MP3
-      </DownloadLink>
-      <DownloadLink
         href={`/api/track/${trackId}/component/${componentId}.flac`}
         small
       >
         FLAC
+      </DownloadLink>
+      <DownloadLink
+        href={`/api/track/${trackId}/component/${componentId}.mp3`}
+        small
+      >
+        MP3
       </DownloadLink>
     </div>
   );

--- a/packages/frontend/src/components/track-details/DownloadLink.tsx
+++ b/packages/frontend/src/components/track-details/DownloadLink.tsx
@@ -5,20 +5,44 @@ import { useWavConversion } from "../../hooks/useWavConversion";
 interface DownloadLinkProps {
   href: string;
   small?: boolean;
+  children: React.ReactNode;
+}
+
+interface DownloadLinkWavProps {
+  href: string;
+  small?: boolean;
   trackId: string;
   type: "full" | "component";
   componentId?: string;
   children: React.ReactNode;
 }
 
-export function DownloadLink({
+export function DownloadLink({ href, small, children }: DownloadLinkProps) {
+  const { appendTokenToUrl } = useAuthToken();
+  const onClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    window.location.href = appendTokenToUrl(href);
+  };
+
+  return (
+    <a
+      href={href}
+      onClick={onClick}
+      className={small ? styles.button.small : styles.button.inactive}
+    >
+      {children}
+    </a>
+  );
+}
+
+export function DownloadLinkWav({
   href,
   small,
   trackId,
   type,
   componentId,
   children,
-}: DownloadLinkProps) {
+}: DownloadLinkWavProps) {
   const { appendTokenToUrl } = useAuthToken();
   const { status, isConverting, startConversion } = useWavConversion({
     trackId,
@@ -26,8 +50,7 @@ export function DownloadLink({
     componentId,
   });
 
-  const isWav = href.endsWith(".wav");
-  const showConversionIcon = isWav && status !== "COMPLETED";
+  const showConversionIcon = status !== "COMPLETED";
 
   const handleClick = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -101,7 +124,7 @@ export function ComponentDownloadButtons({
 }) {
   return (
     <div className="space-x-2">
-      <DownloadLink
+      <DownloadLinkWav
         href={`/api/track/${trackId}/component/${componentId}.wav`}
         small
         trackId={trackId}
@@ -109,22 +132,16 @@ export function ComponentDownloadButtons({
         componentId={componentId}
       >
         WAV
-      </DownloadLink>
+      </DownloadLinkWav>
       <DownloadLink
         href={`/api/track/${trackId}/component/${componentId}.mp3`}
         small
-        trackId={trackId}
-        type="component"
-        componentId={componentId}
       >
         MP3
       </DownloadLink>
       <DownloadLink
         href={`/api/track/${trackId}/component/${componentId}.flac`}
         small
-        trackId={trackId}
-        type="component"
-        componentId={componentId}
       >
         FLAC
       </DownloadLink>

--- a/packages/frontend/src/components/track-details/DownloadLink.tsx
+++ b/packages/frontend/src/components/track-details/DownloadLink.tsx
@@ -30,9 +30,12 @@ export function DownloadLink({
   const showConversionIcon = isWav && status !== "COMPLETED";
 
   const handleClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+
     if (showConversionIcon) {
-      e.preventDefault();
       startConversion();
+    } else {
+      window.location.href = appendTokenToUrl(href);
     }
   };
 

--- a/packages/frontend/src/components/track-details/DownloadLink.tsx
+++ b/packages/frontend/src/components/track-details/DownloadLink.tsx
@@ -1,36 +1,90 @@
 import { useAuthToken } from "../../hooks/useAuthToken";
 import { styles } from "../../styles/common";
+import { useWavConversion } from "../../hooks/useWavConversion";
 
 interface DownloadLinkProps {
   href: string;
-  onClick?: (e: React.MouseEvent) => void;
-  className?: string;
-  children: React.ReactNode;
   small?: boolean;
+  trackId: string;
+  type: "full" | "component";
+  componentId?: string;
+  children: React.ReactNode;
 }
 
 export function DownloadLink({
   href,
-  onClick,
-  className,
+  small,
+  trackId,
+  type,
+  componentId,
   children,
-  small = false,
 }: DownloadLinkProps) {
   const { appendTokenToUrl } = useAuthToken();
-  const defaultOnClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    window.location.href = appendTokenToUrl(href);
+  const { status, isConverting, startConversion } = useWavConversion({
+    trackId,
+    type,
+    componentId,
+  });
+
+  const isWav = href.endsWith(".wav");
+  const showConversionIcon = isWav && status !== "COMPLETED";
+
+  const handleClick = async (e: React.MouseEvent) => {
+    if (showConversionIcon) {
+      e.preventDefault();
+      startConversion();
+    }
   };
 
   return (
     <a
-      href={href}
-      onClick={onClick || defaultOnClick}
-      className={
-        className || (small ? styles.button.small : styles.button.inactive)
-      }
+      href={status === "COMPLETED" ? href : "#"}
+      onClick={handleClick}
+      className={`inline-flex items-center space-x-1 ${
+        small ? "text-sm" : ""
+      } text-primary-600 hover:text-primary-700 font-medium`}
+      download
     >
-      {children}
+      {showConversionIcon ? (
+        isConverting ? (
+          <svg
+            className="animate-spin h-4 w-4"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+        ) : (
+          <svg
+            className="h-4 w-4"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+        )
+      ) : null}
+      <span>{children}</span>
     </a>
   );
 }
@@ -47,18 +101,27 @@ export function ComponentDownloadButtons({
       <DownloadLink
         href={`/api/track/${trackId}/component/${componentId}.wav`}
         small
+        trackId={trackId}
+        type="component"
+        componentId={componentId}
       >
         WAV
       </DownloadLink>
       <DownloadLink
         href={`/api/track/${trackId}/component/${componentId}.mp3`}
         small
+        trackId={trackId}
+        type="component"
+        componentId={componentId}
       >
         MP3
       </DownloadLink>
       <DownloadLink
         href={`/api/track/${trackId}/component/${componentId}.flac`}
         small
+        trackId={trackId}
+        type="component"
+        componentId={componentId}
       >
         FLAC
       </DownloadLink>

--- a/packages/frontend/src/components/track-details/DownloadLink.tsx
+++ b/packages/frontend/src/components/track-details/DownloadLink.tsx
@@ -1,6 +1,7 @@
 import { useAuthToken } from "../../hooks/useAuthToken";
 import { styles } from "../../styles/common";
 import { useWavConversion } from "../../hooks/useWavConversion";
+import { Track } from "@/types";
 
 interface DownloadLinkProps {
   href: string;
@@ -115,32 +116,54 @@ export function DownloadLinkWav({
   );
 }
 
+interface WavDownloadButtonProps {
+  track: Track;
+  componentId: string;
+}
+
+function WavDownloadButton({ track, componentId }: WavDownloadButtonProps) {
+  const downloadProps = {
+    href: `/api/track/${track.id}/component/${componentId}.wav`,
+    children: "WAV",
+    small: true,
+  };
+
+  const component = track.components.find(
+    (component) => component.id === componentId
+  );
+
+  if (component?.wavConversionStatus === "COMPLETED") {
+    return <DownloadLink {...downloadProps} />;
+  }
+
+  return (
+    <DownloadLinkWav
+      {...downloadProps}
+      trackId={track.id}
+      type="component"
+      componentId={componentId}
+    />
+  );
+}
+
 export function ComponentDownloadButtons({
-  trackId,
+  track,
   componentId,
 }: {
-  trackId: string;
+  track: Track;
   componentId: string;
 }) {
   return (
     <div className="space-x-2">
-      <DownloadLinkWav
-        href={`/api/track/${trackId}/component/${componentId}.wav`}
-        small
-        trackId={trackId}
-        type="component"
-        componentId={componentId}
-      >
-        WAV
-      </DownloadLinkWav>
+      <WavDownloadButton track={track} componentId={componentId} />
       <DownloadLink
-        href={`/api/track/${trackId}/component/${componentId}.flac`}
+        href={`/api/track/${track.id}/component/${componentId}.flac`}
         small
       >
         FLAC
       </DownloadLink>
       <DownloadLink
-        href={`/api/track/${trackId}/component/${componentId}.mp3`}
+        href={`/api/track/${track.id}/component/${componentId}.mp3`}
         small
       >
         MP3

--- a/packages/frontend/src/components/track-details/FullTrackSection.tsx
+++ b/packages/frontend/src/components/track-details/FullTrackSection.tsx
@@ -26,18 +26,36 @@ export function FullTrackSection({ track }: FullTrackSectionProps) {
         )}
       </div>
       <div className="mt-4 flex flex-wrap gap-4">
-        <DownloadLink href={`/api/track/${track.id}/original`}>
+        <DownloadLink
+          href={`/api/track/${track.id}/original`}
+          trackId={track.id}
+          type="full"
+        >
           Download Original {track.originalFormat.toUpperCase()} File
         </DownloadLink>
-        <DownloadLink href={`/api/track/${track.id}/full.wav`}>
-          WAV
-        </DownloadLink>
-        <DownloadLink href={`/api/track/${track.id}/full.mp3`}>
-          MP3
-        </DownloadLink>
-        <DownloadLink href={`/api/track/${track.id}/full.flac`}>
-          FLAC
-        </DownloadLink>
+        <div className="flex space-x-4">
+          <DownloadLink
+            href={`/api/track/${track.id}/full.wav`}
+            trackId={track.id}
+            type="full"
+          >
+            WAV
+          </DownloadLink>
+          <DownloadLink
+            href={`/api/track/${track.id}/full.mp3`}
+            trackId={track.id}
+            type="full"
+          >
+            MP3
+          </DownloadLink>
+          <DownloadLink
+            href={`/api/track/${track.id}/full.flac`}
+            trackId={track.id}
+            type="full"
+          >
+            FLAC
+          </DownloadLink>
+        </div>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/track-details/FullTrackSection.tsx
+++ b/packages/frontend/src/components/track-details/FullTrackSection.tsx
@@ -35,6 +35,9 @@ export function FullTrackSection({ track }: FullTrackSectionProps) {
         <DownloadLink href={`/api/track/${track.id}/full.mp3`}>
           MP3
         </DownloadLink>
+        <DownloadLink href={`/api/track/${track.id}/full.flac`}>
+          FLAC
+        </DownloadLink>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/track-details/FullTrackSection.tsx
+++ b/packages/frontend/src/components/track-details/FullTrackSection.tsx
@@ -5,6 +5,23 @@ import { getAudioUrl } from "../../hooks/useAuthToken";
 import { styles } from "../../styles/common";
 import { TrackWaveformPlaceholder } from "../track-list/TrackList";
 
+interface WavDownloadButtonProps {
+  track: Track;
+}
+
+function WavDownloadButton({ track }: WavDownloadButtonProps) {
+  const downloadProps = {
+    href: `/api/track/${track.id}/full.wav`,
+    children: "WAV",
+  };
+
+  if (track.wavConversionStatus === "COMPLETED") {
+    return <DownloadLink {...downloadProps} />;
+  }
+
+  return <DownloadLinkWav {...downloadProps} trackId={track.id} type="full" />;
+}
+
 interface FullTrackSectionProps {
   track: Track;
 }
@@ -29,18 +46,12 @@ export function FullTrackSection({ track }: FullTrackSectionProps) {
         <DownloadLink href={`/api/track/${track.id}/original`}>
           Download Original {track.originalFormat.toUpperCase()} File
         </DownloadLink>
-        <DownloadLinkWav
-          href={`/api/track/${track.id}/full.wav`}
-          trackId={track.id}
-          type="full"
-        >
-          WAV
-        </DownloadLinkWav>
-        <DownloadLink href={`/api/track/${track.id}/full.mp3`}>
-          MP3
-        </DownloadLink>
+        <WavDownloadButton track={track} />
         <DownloadLink href={`/api/track/${track.id}/full.flac`}>
           FLAC
+        </DownloadLink>
+        <DownloadLink href={`/api/track/${track.id}/full.mp3`}>
+          MP3
         </DownloadLink>
       </div>
     </div>

--- a/packages/frontend/src/components/track-details/FullTrackSection.tsx
+++ b/packages/frontend/src/components/track-details/FullTrackSection.tsx
@@ -1,6 +1,6 @@
 import { Track } from "@/types";
 import { SyncedWaveform } from "../waveform/SyncedWaveform";
-import { DownloadLink } from "./DownloadLink";
+import { DownloadLink, DownloadLinkWav } from "./DownloadLink";
 import { getAudioUrl } from "../../hooks/useAuthToken";
 import { styles } from "../../styles/common";
 import { TrackWaveformPlaceholder } from "../track-list/TrackList";
@@ -26,36 +26,22 @@ export function FullTrackSection({ track }: FullTrackSectionProps) {
         )}
       </div>
       <div className="mt-4 flex flex-wrap gap-4">
-        <DownloadLink
-          href={`/api/track/${track.id}/original`}
+        <DownloadLink href={`/api/track/${track.id}/original`}>
+          Download Original {track.originalFormat.toUpperCase()} File
+        </DownloadLink>
+        <DownloadLinkWav
+          href={`/api/track/${track.id}/full.wav`}
           trackId={track.id}
           type="full"
         >
-          Download Original {track.originalFormat.toUpperCase()} File
+          WAV
+        </DownloadLinkWav>
+        <DownloadLink href={`/api/track/${track.id}/full.mp3`}>
+          MP3
         </DownloadLink>
-        <div className="flex space-x-4">
-          <DownloadLink
-            href={`/api/track/${track.id}/full.wav`}
-            trackId={track.id}
-            type="full"
-          >
-            WAV
-          </DownloadLink>
-          <DownloadLink
-            href={`/api/track/${track.id}/full.mp3`}
-            trackId={track.id}
-            type="full"
-          >
-            MP3
-          </DownloadLink>
-          <DownloadLink
-            href={`/api/track/${track.id}/full.flac`}
-            trackId={track.id}
-            type="full"
-          >
-            FLAC
-          </DownloadLink>
-        </div>
+        <DownloadLink href={`/api/track/${track.id}/full.flac`}>
+          FLAC
+        </DownloadLink>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/track-details/TrackComponent.tsx
+++ b/packages/frontend/src/components/track-details/TrackComponent.tsx
@@ -6,13 +6,13 @@ import { styles } from "../../styles/common";
 
 interface TrackComponentProps {
   component: Track["components"][0];
-  trackId: string;
+  track: Track;
   isGridView: boolean;
 }
 
 export function TrackComponent({
   component,
-  trackId,
+  track,
   isGridView,
 }: TrackComponentProps) {
   return (
@@ -30,10 +30,7 @@ export function TrackComponent({
           </h3>
           {isGridView && <p className={styles.text.label}>{component.type}</p>}
         </div>
-        <ComponentDownloadButtons
-          trackId={trackId}
-          componentId={component.id}
-        />
+        <ComponentDownloadButtons track={track} componentId={component.id} />
       </div>
       <SyncedWaveform
         waveformData={component.waveformData}
@@ -42,7 +39,7 @@ export function TrackComponent({
         color="#4b5563"
         progressColor="#6366f1"
         audioUrl={getAudioUrl(
-          `/api/track/${trackId}/component/${component.id}.mp3`
+          `/api/track/${track.id}/component/${component.id}.mp3`
         )}
       />
     </div>

--- a/packages/frontend/src/contexts/NotificationsContext.tsx
+++ b/packages/frontend/src/contexts/NotificationsContext.tsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface Notification {
+  id: string;
+  type: "success" | "error" | "info" | "warning";
+  title: string;
+  message: string;
+}
+
+interface NotificationsContextType {
+  notifications: Notification[];
+  addNotification: (notification: Omit<Notification, "id">) => void;
+  removeNotification: (id: string) => void;
+}
+
+const NotificationsContext = createContext<NotificationsContextType | null>(
+  null
+);
+
+export function useNotifications() {
+  const context = useContext(NotificationsContext);
+  if (!context) {
+    throw new Error(
+      "useNotifications must be used within a NotificationsProvider"
+    );
+  }
+  return context;
+}
+
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  const addNotification = (notification: Omit<Notification, "id">) => {
+    const id = Math.random().toString(36).substr(2, 9);
+    setNotifications((prev) => [...prev, { ...notification, id }]);
+
+    // Automatically remove notification after 5 seconds
+    setTimeout(() => {
+      removeNotification(id);
+    }, 5000);
+  };
+
+  const removeNotification = (id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  };
+
+  return (
+    <NotificationsContext.Provider
+      value={{
+        notifications,
+        addNotification,
+        removeNotification,
+      }}
+    >
+      {children}
+      {/* Toast notifications container */}
+      <div className="fixed bottom-4 right-4 z-50 space-y-2">
+        {notifications.map((notification) => (
+          <div
+            key={notification.id}
+            className={`p-4 rounded-lg shadow-lg max-w-sm ${
+              notification.type === "success"
+                ? "bg-green-100 text-green-800"
+                : notification.type === "error"
+                ? "bg-red-100 text-red-800"
+                : notification.type === "warning"
+                ? "bg-yellow-100 text-yellow-800"
+                : "bg-blue-100 text-blue-800"
+            }`}
+          >
+            <div className="flex justify-between items-start">
+              <div>
+                <h3 className="font-semibold">{notification.title}</h3>
+                <p className="text-sm mt-1">{notification.message}</p>
+              </div>
+              <button
+                onClick={() => removeNotification(notification.id)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </NotificationsContext.Provider>
+  );
+}

--- a/packages/frontend/src/hooks/useWavConversion.tsx
+++ b/packages/frontend/src/hooks/useWavConversion.tsx
@@ -67,9 +67,9 @@ export function useWavConversion({
         }
       };
 
-      // Check immediately and then every 2 seconds
+      // Check immediately and then every 5 seconds
       checkStatus();
-      intervalId = setInterval(checkStatus, 2000);
+      intervalId = setInterval(checkStatus, 5000);
     }
 
     return () => {

--- a/packages/frontend/src/hooks/useWavConversion.tsx
+++ b/packages/frontend/src/hooks/useWavConversion.tsx
@@ -31,7 +31,11 @@ export function useWavConversion({
           const token = getToken();
           if (!token) return;
 
-          const response = await fetch(`/api/track/${trackId}/wav-status`, {
+          const statusUrl = componentId
+            ? `/api/track/${trackId}/component/${componentId}/wav-status`
+            : `/api/track/${trackId}/wav-status`;
+
+          const response = await fetch(statusUrl, {
             headers: {
               Authorization: `Bearer ${token}`,
             },

--- a/packages/frontend/src/hooks/useWavConversion.tsx
+++ b/packages/frontend/src/hooks/useWavConversion.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect } from "react";
+import { useNotifications } from "../contexts/NotificationsContext";
+import { useAuthToken } from "../hooks/useAuthToken";
+
+type ConversionType = "full" | "component";
+type ConversionStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED" | "FAILED";
+
+interface UseWavConversionProps {
+  trackId: string;
+  type: ConversionType;
+  componentId?: string;
+}
+
+export function useWavConversion({
+  trackId,
+  type,
+  componentId,
+}: UseWavConversionProps) {
+  const [status, setStatus] = useState<ConversionStatus>("NOT_STARTED");
+  const [isConverting, setIsConverting] = useState(false);
+  const { addNotification } = useNotifications();
+  const { getToken } = useAuthToken();
+
+  // Poll for status updates when conversion is in progress
+  useEffect(() => {
+    let intervalId: NodeJS.Timeout;
+
+    if (isConverting) {
+      const checkStatus = async () => {
+        try {
+          const token = getToken();
+          if (!token) return;
+
+          const response = await fetch(`/api/track/${trackId}/wav-status`, {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          });
+          const data = await response.json();
+
+          if (data.status === "success") {
+            setStatus(data.data.conversionStatus);
+
+            if (data.data.conversionStatus === "COMPLETED") {
+              setIsConverting(false);
+              addNotification({
+                type: "success",
+                title: "WAV Conversion Complete",
+                message: "Your WAV file is ready for download.",
+              });
+            } else if (data.data.conversionStatus === "FAILED") {
+              setIsConverting(false);
+              addNotification({
+                type: "error",
+                title: "WAV Conversion Failed",
+                message:
+                  "There was an error converting your file to WAV format.",
+              });
+            }
+          }
+        } catch (error) {
+          console.error("Error checking WAV conversion status:", error);
+        }
+      };
+
+      // Check immediately and then every 2 seconds
+      checkStatus();
+      intervalId = setInterval(checkStatus, 2000);
+    }
+
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
+  }, [trackId, isConverting, addNotification, getToken]);
+
+  const startConversion = async () => {
+    try {
+      setIsConverting(true);
+      const token = getToken();
+      if (!token) return;
+
+      const response = await fetch(`/api/track/${trackId}/convert-wav`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          type,
+          componentId,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (data.status === "success") {
+        addNotification({
+          type: "info",
+          title: "WAV Conversion Started",
+          message: "Your file is being converted to WAV format.",
+        });
+      } else if (data.status === "in_progress") {
+        addNotification({
+          type: "info",
+          title: "WAV Conversion In Progress",
+          message: "Your file is already being converted to WAV format.",
+        });
+      }
+    } catch (error) {
+      console.error("Error starting WAV conversion:", error);
+      setIsConverting(false);
+      addNotification({
+        type: "error",
+        title: "WAV Conversion Error",
+        message: "Failed to start WAV conversion.",
+      });
+    }
+  };
+
+  return {
+    status,
+    isConverting,
+    startConversion,
+  };
+}

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -11,6 +11,9 @@ export interface Track {
   artist: string;
   coverArt: string | null;
   originalUrl: string | null;
+  fullTrackWavUrl: string | null;
+  fullTrackMp3Url: string | null;
+  fullTrackFlacUrl: string | null;
   waveformData: number[];
   duration?: number;
   isPublic: boolean;

--- a/packages/media/src/routes/media.ts
+++ b/packages/media/src/routes/media.ts
@@ -9,7 +9,7 @@ const conversionOptionsSchema = z.object({
   trackId: z.string().uuid(),
 });
 
-// Convert XM file to WAV/MP3/FLAC format
+// Convert XM file to MP3/FLAC format
 router.post("/convert", async (req, res, next) => {
   try {
     // Parse conversion options

--- a/packages/media/src/routes/media.ts
+++ b/packages/media/src/routes/media.ts
@@ -9,7 +9,7 @@ const conversionOptionsSchema = z.object({
   trackId: z.string().uuid(),
 });
 
-// Convert XM file to WAV/MP3 format
+// Convert XM file to WAV/MP3/FLAC format
 router.post("/convert", async (req, res, next) => {
   try {
     // Parse conversion options

--- a/packages/media/src/routes/media.ts
+++ b/packages/media/src/routes/media.ts
@@ -1,12 +1,26 @@
 import { Router } from "express";
 import { AppError } from "../middleware/errorHandler";
-import { queueConversion, conversionQueue } from "../services/queue";
+import {
+  queueConversion,
+  conversionQueue,
+  queueWavConversion,
+  wavConversionQueue,
+} from "../services/queue";
 import { z } from "zod";
+import { PrismaService, config } from "@wavtopia/core-storage";
+
+const prisma = new PrismaService(config.database).db;
 
 export const router = Router();
 
 const conversionOptionsSchema = z.object({
   trackId: z.string().uuid(),
+});
+
+const wavConversionOptionsSchema = z.object({
+  trackId: z.string().uuid(),
+  type: z.enum(["full", "component"]),
+  componentId: z.string().uuid().optional(),
 });
 
 // Convert XM file to MP3/FLAC format
@@ -50,6 +64,72 @@ router.get("/status/:jobId", async (req, res, next) => {
         state,
         progress,
         result,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Request WAV conversion
+router.post("/convert-wav", async (req, res, next) => {
+  try {
+    const options = wavConversionOptionsSchema.parse(req.body);
+
+    // Check if track exists and get current status
+    const track = await prisma.track.findUnique({
+      where: { id: options.trackId },
+      select: { wavConversionStatus: true },
+    });
+
+    if (!track) {
+      throw new AppError(404, "Track not found");
+    }
+
+    // If conversion is already in progress, return existing status
+    if (track.wavConversionStatus === "IN_PROGRESS") {
+      return res.json({
+        status: "in_progress",
+        message: "WAV conversion is already in progress",
+      });
+    }
+
+    const jobId = await queueWavConversion(
+      options.trackId,
+      options.type,
+      options.componentId
+    );
+
+    res.json({
+      status: "success",
+      data: {
+        jobId,
+        message: "WAV conversion has been queued",
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Get WAV conversion status
+router.get("/wav-status/:trackId", async (req, res, next) => {
+  try {
+    const { trackId } = req.params;
+
+    const track = await prisma.track.findUnique({
+      where: { id: trackId },
+      select: { wavConversionStatus: true },
+    });
+
+    if (!track) {
+      throw new AppError(404, "Track not found");
+    }
+
+    res.json({
+      status: "success",
+      data: {
+        conversionStatus: track.wavConversionStatus,
       },
     });
   } catch (error) {

--- a/packages/media/src/routes/media.ts
+++ b/packages/media/src/routes/media.ts
@@ -112,7 +112,7 @@ router.post("/convert-wav", async (req, res, next) => {
   }
 });
 
-// Get WAV conversion status
+// Get track WAV conversion status
 router.get("/wav-status/:trackId", async (req, res, next) => {
   try {
     const { trackId } = req.params;
@@ -130,6 +130,31 @@ router.get("/wav-status/:trackId", async (req, res, next) => {
       status: "success",
       data: {
         conversionStatus: track.wavConversionStatus,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Get component WAV conversion status
+router.get("/component/:componentId/wav-status", async (req, res, next) => {
+  try {
+    const { componentId } = req.params;
+
+    const component = await prisma.component.findUnique({
+      where: { id: componentId },
+      select: { wavConversionStatus: true },
+    });
+
+    if (!component) {
+      throw new AppError(404, "Component not found");
+    }
+
+    res.json({
+      status: "success",
+      data: {
+        conversionStatus: component.wavConversionStatus,
       },
     });
   } catch (error) {

--- a/packages/media/src/services/flac-converter.ts
+++ b/packages/media/src/services/flac-converter.ts
@@ -1,0 +1,43 @@
+import { promisify } from "util";
+import { exec } from "child_process";
+import { writeFile, mkdtemp, rm, readFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AppError } from "../middleware/errorHandler";
+
+const execAsync = promisify(exec);
+
+export async function convertWAVToFLAC(wavBuffer: Buffer): Promise<Buffer> {
+  try {
+    // Create temporary directory
+    const tempDir = await mkdtemp(join(tmpdir(), "wavtopia-flac-"));
+    const wavPath = join(tempDir, "input.wav");
+    const flacPath = join(tempDir, "output.flac");
+
+    try {
+      // Write WAV file to temp directory
+      await writeFile(wavPath, wavBuffer);
+
+      // Convert to FLAC using FFmpeg
+      // -compression_level 5 provides a good balance between compression and speed
+      // Range is 0-12, where 0 is fastest/largest, 12 is slowest/smallest
+      const { stderr } = await execAsync(
+        `ffmpeg -i "${wavPath}" -c:a flac -compression_level 5 "${flacPath}"`
+      );
+
+      if (stderr) {
+        console.error("FLAC conversion stderr:", stderr);
+      }
+
+      // Read the FLAC file
+      const flacBuffer = await readFile(flacPath);
+      return flacBuffer;
+    } finally {
+      // Clean up temporary directory
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  } catch (error) {
+    console.error("Error converting WAV to FLAC:", error);
+    throw new AppError(500, "Failed to convert WAV to FLAC");
+  }
+}

--- a/packages/media/src/services/queue.ts
+++ b/packages/media/src/services/queue.ts
@@ -148,15 +148,7 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
         const waveformResult = await generateWaveformData(component.buffer);
         console.log(`Generated waveform data for component: ${component.name}`);
 
-        const [wavUrl, mp3Url, flacUrl] = await Promise.all([
-          uploadFile(
-            {
-              buffer: component.buffer,
-              originalname: `${componentName}.wav`,
-              mimetype: "audio/wav",
-            } as StorageFile,
-            "components/"
-          ),
+        const [mp3Url, flacUrl] = await Promise.all([
           uploadFile(
             {
               buffer: mp3Buffer,
@@ -179,7 +171,6 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
         return {
           name: component.name,
           type: component.type,
-          wavUrl,
           mp3Url,
           flacUrl,
           waveformData: waveformResult.peaks,
@@ -219,7 +210,6 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
           deleteFile(fullTrackFlacUrl),
           ...(coverArtUrl ? [deleteFile(coverArtUrl)] : []),
           ...componentUploads.flatMap((comp) => [
-            deleteFile(comp.wavUrl),
             deleteFile(comp.mp3Url),
             deleteFile(comp.flacUrl),
           ]),

--- a/packages/media/src/services/queue.ts
+++ b/packages/media/src/services/queue.ts
@@ -68,33 +68,33 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
 
     // Convert XM to WAV
     console.log("Converting XM to WAV...");
-    const { fullTrackBuffer, components } = await convertXMToWAV(
+    const { fullTrackWavBuffer, components } = await convertXMToWAV(
       originalFile.buffer
     );
     console.log("XM conversion complete. Components:", components.length);
 
     // Generate waveform data for full track
     console.log("Generating waveform data for full track...");
-    const waveformResult = await generateWaveformData(fullTrackBuffer);
+    const waveformResult = await generateWaveformData(fullTrackWavBuffer);
     console.log("Full track waveform data generated");
 
     // Convert full track to MP3
     console.log("Converting full track to MP3...");
-    const fullTrackMp3Buffer = await convertWAVToMP3(fullTrackBuffer);
+    const fullTrackMp3Buffer = await convertWAVToMP3(fullTrackWavBuffer);
     console.log("Full track MP3 conversion complete");
 
     // Convert full track to FLAC
     console.log("Converting full track to FLAC...");
-    const fullTrackFlacBuffer = await convertWAVToFLAC(fullTrackBuffer);
+    const fullTrackFlacBuffer = await convertWAVToFLAC(fullTrackWavBuffer);
     console.log("Full track FLAC conversion complete");
 
     // Upload full track files
     console.log("Uploading full track files...");
-    const [fullTrackUrl, fullTrackMp3Url, fullTrackFlacUrl] = await Promise.all(
-      [
+    const [fullTrackWavUrl, fullTrackMp3Url, fullTrackFlacUrl] =
+      await Promise.all([
         uploadFile(
           {
-            buffer: fullTrackBuffer,
+            buffer: fullTrackWavBuffer,
             originalname: `${originalName}_full.wav`,
             mimetype: "audio/wav",
           } as StorageFile,
@@ -116,8 +116,7 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
           } as StorageFile,
           "tracks/"
         ),
-      ]
-    );
+      ]);
     console.log("Full track files uploaded");
 
     // Convert and upload component files
@@ -186,7 +185,7 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
         where: { id: trackId },
         data: {
           originalUrl,
-          fullTrackUrl,
+          fullTrackWavUrl,
           fullTrackMp3Url,
           fullTrackFlacUrl,
           waveformData: waveformResult.peaks,
@@ -207,7 +206,7 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
       try {
         await Promise.all([
           deleteFile(originalUrl),
-          deleteFile(fullTrackUrl),
+          deleteFile(fullTrackWavUrl),
           deleteFile(fullTrackMp3Url),
           deleteFile(fullTrackFlacUrl),
           ...(coverArtUrl ? [deleteFile(coverArtUrl)] : []),

--- a/packages/media/src/services/queue.ts
+++ b/packages/media/src/services/queue.ts
@@ -88,35 +88,27 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
     const fullTrackFlacBuffer = await convertWAVToFLAC(fullTrackWavBuffer);
     console.log("Full track FLAC conversion complete");
 
-    // Upload full track files
+    // Upload full track files, MP3 and FLAC. WAV is not uploaded, to save space.
+    // It can be converted from FLAC on demand.
     console.log("Uploading full track files...");
-    const [fullTrackWavUrl, fullTrackMp3Url, fullTrackFlacUrl] =
-      await Promise.all([
-        uploadFile(
-          {
-            buffer: fullTrackWavBuffer,
-            originalname: `${originalName}_full.wav`,
-            mimetype: "audio/wav",
-          } as StorageFile,
-          "tracks/"
-        ),
-        uploadFile(
-          {
-            buffer: fullTrackMp3Buffer,
-            originalname: `${originalName}_full.mp3`,
-            mimetype: "audio/mpeg",
-          } as StorageFile,
-          "tracks/"
-        ),
-        uploadFile(
-          {
-            buffer: fullTrackFlacBuffer,
-            originalname: `${originalName}_full.flac`,
-            mimetype: "audio/flac",
-          } as StorageFile,
-          "tracks/"
-        ),
-      ]);
+    const [fullTrackMp3Url, fullTrackFlacUrl] = await Promise.all([
+      uploadFile(
+        {
+          buffer: fullTrackMp3Buffer,
+          originalname: `${originalName}_full.mp3`,
+          mimetype: "audio/mpeg",
+        } as StorageFile,
+        "tracks/"
+      ),
+      uploadFile(
+        {
+          buffer: fullTrackFlacBuffer,
+          originalname: `${originalName}_full.flac`,
+          mimetype: "audio/flac",
+        } as StorageFile,
+        "tracks/"
+      ),
+    ]);
     console.log("Full track files uploaded");
 
     // Convert and upload component files
@@ -185,7 +177,6 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
         where: { id: trackId },
         data: {
           originalUrl,
-          fullTrackWavUrl,
           fullTrackMp3Url,
           fullTrackFlacUrl,
           waveformData: waveformResult.peaks,
@@ -206,7 +197,6 @@ conversionQueue.process(async (job: Job<ConversionJob>) => {
       try {
         await Promise.all([
           deleteFile(originalUrl),
-          deleteFile(fullTrackWavUrl),
           deleteFile(fullTrackMp3Url),
           deleteFile(fullTrackFlacUrl),
           ...(coverArtUrl ? [deleteFile(coverArtUrl)] : []),

--- a/packages/media/src/services/storage.ts
+++ b/packages/media/src/services/storage.ts
@@ -53,6 +53,8 @@ function getMimeType(filename: string): string {
       return "audio/wav";
     case "xm":
       return "audio/x-xm";
+    case "flac":
+      return "audio/flac";
     case "jpg":
     case "jpeg":
       return "image/jpeg";

--- a/packages/media/src/services/storage.ts
+++ b/packages/media/src/services/storage.ts
@@ -5,6 +5,7 @@ import {
   normalizeFilePath,
 } from "@wavtopia/core-storage";
 import fs from "fs/promises";
+import internal from "stream";
 
 const storageService = new StorageService(config.storage);
 
@@ -26,6 +27,10 @@ export async function deleteFile(fileName: string): Promise<void> {
 
 export async function getFileUrl(fileName: string): Promise<string> {
   return await storageService.getFileUrl(fileName);
+}
+
+export async function getObject(fileName: string): Promise<internal.Readable> {
+  return await storageService.getObject(fileName);
 }
 
 export async function getLocalFile(

--- a/packages/media/src/services/wav-converter.ts
+++ b/packages/media/src/services/wav-converter.ts
@@ -16,7 +16,7 @@ interface ConvertedComponent {
 }
 
 interface ConversionResult {
-  fullTrackBuffer: Buffer;
+  fullTrackWavBuffer: Buffer;
   components: ConvertedComponent[];
 }
 
@@ -47,7 +47,9 @@ export async function convertXMToWAV(
       }
 
       // Read the full track WAV
-      const fullTrackBuffer = await readWavFile(join(tempDir, fullTrackOutput));
+      const fullTrackWavBuffer = await readWavFile(
+        join(tempDir, fullTrackOutput)
+      );
 
       // Then convert individual components
       const { stderr: componentsStderr } = await execAsync(
@@ -85,7 +87,7 @@ export async function convertXMToWAV(
       );
 
       return {
-        fullTrackBuffer,
+        fullTrackWavBuffer,
         components: convertedComponents,
       };
     } finally {

--- a/packages/media/src/services/wav-converter.ts
+++ b/packages/media/src/services/wav-converter.ts
@@ -36,7 +36,7 @@ export async function convertXMToWAV(
 
       // First, convert the full track
       const { stderr: fullTrackStderr } = await execAsync(
-        `"${config.tools.exportToWavPath}" "${xmPath}" "${join(
+        `"${config.tools.exportToWavPath}" "${xmPath}" --output "${join(
           tempDir,
           fullTrackOutput
         )}"`
@@ -51,7 +51,7 @@ export async function convertXMToWAV(
 
       // Then convert individual components
       const { stderr: componentsStderr } = await execAsync(
-        `"${config.tools.exportToWavPath}" "${xmPath}" "${join(
+        `"${config.tools.exportToWavPath}" "${xmPath}" --output "${join(
           tempDir,
           componentsBaseName
         )}" --multi-track`


### PR DESCRIPTION
This PR introduces several improvements to audio format handling:

- Add FLAC format support for both full tracks and components
- Make WAV conversion optional and on-demand instead of automatic
- Track WAV conversion status for both full tracks and components
- Add new API endpoints for WAV conversion and status checking
- Update UI to show conversion status and trigger WAV conversions
- Rename `fullTrackUrl` to `fullTrackWavUrl` for clarity
- Add `.flac` to gitignore

Breaking changes:
- Renamed `fullTrackUrl` to `fullTrackWavUrl` in Track model
- WAV URLs for components are now optional