### PR TITLE
Add preview/sync playback mode toggle for tracks

### DIFF
--- a/packages/backend/src/routes/track.ts
+++ b/packages/backend/src/routes/track.ts
@@ -260,7 +260,6 @@ router.get(
         format === "mp3" ? "audio/mpeg" : "audio/wav"
       );
       res.setHeader("Transfer-Encoding", "chunked");
-      res.setHeader("Cache-Control", "no-cache");
       res.setHeader(
         "Content-Disposition",
         `attachment; filename="${track.title}.${format}"`

--- a/packages/frontend/src/components/track-details/ComponentsSection.tsx
+++ b/packages/frontend/src/components/track-details/ComponentsSection.tsx
@@ -1,4 +1,5 @@
 import { Track } from "@/types";
+import { PlayModeToggle } from "./PlayModeToggle";
 import { ViewModeToggle, ViewMode } from "./ViewModeToggle";
 import { TrackComponent } from "./TrackComponent";
 import { styles } from "../../styles/common";
@@ -18,10 +19,13 @@ export function ComponentsSection({
     <div className={styles.layout.stack}>
       <div className={styles.container.flexBetween}>
         <h2 className={styles.text.heading}>Components</h2>
-        <ViewModeToggle
-          viewMode={viewMode}
-          onViewModeChange={onViewModeChange}
-        />
+        <div className={styles.container.flexRow}>
+          <PlayModeToggle />
+          <ViewModeToggle
+            viewMode={viewMode}
+            onViewModeChange={onViewModeChange}
+          />
+        </div>
       </div>
 
       <div

--- a/packages/frontend/src/components/track-details/FullTrackSection.tsx
+++ b/packages/frontend/src/components/track-details/FullTrackSection.tsx
@@ -49,7 +49,8 @@ export function FullTrackSection({ track }: FullTrackSectionProps) {
             duration={track.duration ?? undefined}
             height={96}
             audioUrl={getAudioUrl(`/api/track/${track.id}/full.mp3`)}
-            isFullTrack={true}
+            isFullTrack
+            preloadMetadata // Irrelevant for synced playback where the full track is loaded
           />
         )}
       </div>

--- a/packages/frontend/src/components/track-details/FullTrackSection.tsx
+++ b/packages/frontend/src/components/track-details/FullTrackSection.tsx
@@ -1,9 +1,9 @@
 import { Track } from "@/types";
-import { SyncedWaveform } from "../waveform/SyncedWaveform";
 import { DownloadLink, ConvertAudioFile } from "./DownloadLink";
 import { getAudioUrl } from "../../hooks/useAuthToken";
 import { styles } from "../../styles/common";
 import { TrackWaveformPlaceholder } from "../track-list/TrackList";
+import { TrackDetailsWaveform } from "@/pages/TrackDetails/components/TrackDetailsWaveform";
 
 interface AudioFileDownloadButtonProps {
   track: Track;
@@ -44,7 +44,7 @@ export function FullTrackSection({ track }: FullTrackSectionProps) {
         {track.originalUrl?.startsWith("file://") ? (
           <TrackWaveformPlaceholder height={96} />
         ) : (
-          <SyncedWaveform
+          <TrackDetailsWaveform
             waveformData={track.waveformData}
             duration={track.duration ?? undefined}
             height={96}

--- a/packages/frontend/src/components/track-details/PlayModeToggle.tsx
+++ b/packages/frontend/src/components/track-details/PlayModeToggle.tsx
@@ -1,0 +1,24 @@
+import { PlaybackContext } from "@/pages/TrackDetails/contexts/PlaybackContext";
+import { useContext } from "react";
+import { Toggle } from "../ui/Toggle";
+
+export function PlayModeToggle() {
+  const playbackContext = useContext(PlaybackContext);
+
+  if (!playbackContext) {
+    return null;
+  }
+
+  const { playMode, setPlayMode } = playbackContext;
+
+  return (
+    <Toggle
+      value={playMode}
+      options={[
+        { value: "preview", label: "Preview" },
+        { value: "sync", label: "Sync" },
+      ]}
+      onChange={setPlayMode}
+    />
+  );
+}

--- a/packages/frontend/src/components/track-details/TrackComponent.tsx
+++ b/packages/frontend/src/components/track-details/TrackComponent.tsx
@@ -1,5 +1,5 @@
 import { Track, Component } from "@/types";
-import { SyncedWaveform } from "../waveform/SyncedWaveform";
+import { TrackDetailsWaveform } from "@/pages/TrackDetails/components/TrackDetailsWaveform";
 import { ComponentDownloadButtons } from "./DownloadLink";
 import { getAudioUrl } from "../../hooks/useAuthToken";
 import { styles } from "../../styles/common";
@@ -31,7 +31,7 @@ export function TrackComponent({
         </div>
         <ComponentDownloadButtons track={track} component={component} />
       </div>
-      <SyncedWaveform
+      <TrackDetailsWaveform
         waveformData={component.waveformData}
         duration={component.duration ?? undefined}
         height={isGridView ? 48 : 64}

--- a/packages/frontend/src/components/track-details/TrackComponent.tsx
+++ b/packages/frontend/src/components/track-details/TrackComponent.tsx
@@ -28,7 +28,6 @@ export function TrackComponent({
           >
             {component.name}
           </h3>
-          {isGridView && <p className={styles.text.label}>{component.type}</p>}
         </div>
         <ComponentDownloadButtons track={track} component={component} />
       </div>

--- a/packages/frontend/src/components/track-details/ViewModeToggle.tsx
+++ b/packages/frontend/src/components/track-details/ViewModeToggle.tsx
@@ -1,4 +1,4 @@
-import { styles } from "../../styles/common";
+import { Switch } from "../ui/Switch";
 
 export type ViewMode = "grid" | "list";
 
@@ -12,22 +12,26 @@ export function ViewModeToggle({
   onViewModeChange,
 }: ViewModeToggleProps) {
   return (
-    <div className="flex gap-2">
+    <div className="inline-flex rounded-lg border border-gray-200 p-1 text-sm">
       <button
         onClick={() => onViewModeChange("grid")}
-        className={`${styles.button.base} ${
-          viewMode === "grid" ? styles.button.active : styles.button.inactive
+        className={`relative rounded-md px-3 py-1.5 transition-colors duration-200 ${
+          viewMode === "grid"
+            ? "bg-primary-600 text-white"
+            : "text-gray-600 hover:text-gray-900"
         }`}
       >
-        Grid View
+        Grid
       </button>
       <button
         onClick={() => onViewModeChange("list")}
-        className={`${styles.button.base} ${
-          viewMode === "list" ? styles.button.active : styles.button.inactive
+        className={`relative rounded-md px-3 py-1.5 transition-colors duration-200 ${
+          viewMode === "list"
+            ? "bg-primary-600 text-white"
+            : "text-gray-600 hover:text-gray-900"
         }`}
       >
-        List View
+        List
       </button>
     </div>
   );

--- a/packages/frontend/src/components/track-details/ViewModeToggle.tsx
+++ b/packages/frontend/src/components/track-details/ViewModeToggle.tsx
@@ -1,4 +1,4 @@
-import { Switch } from "../ui/Switch";
+import { Toggle } from "../ui/Toggle";
 
 export type ViewMode = "grid" | "list";
 
@@ -12,27 +12,13 @@ export function ViewModeToggle({
   onViewModeChange,
 }: ViewModeToggleProps) {
   return (
-    <div className="inline-flex rounded-lg border border-gray-200 p-1 text-sm">
-      <button
-        onClick={() => onViewModeChange("grid")}
-        className={`relative rounded-md px-3 py-1.5 transition-colors duration-200 ${
-          viewMode === "grid"
-            ? "bg-primary-600 text-white"
-            : "text-gray-600 hover:text-gray-900"
-        }`}
-      >
-        Grid
-      </button>
-      <button
-        onClick={() => onViewModeChange("list")}
-        className={`relative rounded-md px-3 py-1.5 transition-colors duration-200 ${
-          viewMode === "list"
-            ? "bg-primary-600 text-white"
-            : "text-gray-600 hover:text-gray-900"
-        }`}
-      >
-        List
-      </button>
-    </div>
+    <Toggle
+      value={viewMode}
+      options={[
+        { value: "grid", label: "Grid" },
+        { value: "list", label: "List" },
+      ]}
+      onChange={onViewModeChange}
+    />
   );
 }

--- a/packages/frontend/src/components/track-list/TrackList.tsx
+++ b/packages/frontend/src/components/track-list/TrackList.tsx
@@ -3,7 +3,7 @@ import { Track } from "@/types";
 import { LoadingState } from "../ui/LoadingState";
 import { ErrorState } from "../ui/ErrorState";
 import { useAuthToken } from "@/hooks/useAuthToken";
-import { TrackListWaveform } from "../waveform/TrackListWaveform";
+import { StreamableWaveform } from "../waveform/StreamableWaveform";
 import { TrackListPlaybackProvider } from "@/contexts/TrackListPlaybackContext";
 import { cn } from "@/utils/cn";
 import { Checkbox } from "../ui/Checkbox";
@@ -304,7 +304,7 @@ export function TrackList({
             {track.originalUrl?.startsWith("file://") ? (
               <TrackWaveformPlaceholder height={48} />
             ) : (
-              <TrackListWaveform
+              <StreamableWaveform
                 waveformData={track.waveformData}
                 duration={track.duration ?? undefined}
                 audioUrl={appendTokenToUrl(`/api/track/${track.id}/full.mp3`)}

--- a/packages/frontend/src/components/ui/Toggle.tsx
+++ b/packages/frontend/src/components/ui/Toggle.tsx
@@ -1,0 +1,38 @@
+interface ToggleOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface ToggleProps<T extends string> {
+  value: T;
+  options: [ToggleOption<T>, ToggleOption<T>];
+  onChange: (value: T) => void;
+  className?: string;
+}
+
+export function Toggle<T extends string>({
+  value,
+  options,
+  onChange,
+  className = "",
+}: ToggleProps<T>) {
+  return (
+    <div
+      className={`inline-flex rounded-lg border border-gray-200 p-1 text-sm ${className}`}
+    >
+      {options.map((option) => (
+        <button
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          className={`relative rounded-md px-3 py-1.5 transition-colors duration-200 ${
+            value === option.value
+              ? "bg-primary-600 text-white"
+              : "text-gray-600 hover:text-gray-900"
+          }`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/waveform/StreamableWaveform.tsx
+++ b/packages/frontend/src/components/waveform/StreamableWaveform.tsx
@@ -1,23 +1,25 @@
 import { useTrackListPlayback } from "@/contexts/TrackListPlaybackContext";
 import { WaveformDisplay } from "./WaveformDisplay";
 
-export interface TrackListWaveformProps {
+export interface StreamableWaveformProps {
   waveformData: number[];
   audioUrl: string;
   duration?: number;
+  preloadMetadata?: boolean;
   height?: number;
   color?: string;
   progressColor?: string;
 }
 
-export function TrackListWaveform({
+export function StreamableWaveform({
   waveformData,
   audioUrl,
   duration,
+  preloadMetadata = false,
   height = 48,
   color = "#4b5563",
   progressColor = "#6366f1",
-}: TrackListWaveformProps) {
+}: StreamableWaveformProps) {
   const trackListContext = useTrackListPlayback();
 
   return (
@@ -30,6 +32,8 @@ export function TrackListWaveform({
       color={color}
       progressColor={progressColor}
       isFullTrack={true}
+      preloadMetadata={preloadMetadata}
+      isStreamable={true}
     />
   );
 }

--- a/packages/frontend/src/components/waveform/SyncedWaveform.tsx
+++ b/packages/frontend/src/components/waveform/SyncedWaveform.tsx
@@ -1,7 +1,7 @@
 import { useSyncedPlayback } from "@/contexts/SyncedPlaybackContext";
 import { WaveformDisplay } from "./WaveformDisplay";
 
-interface SyncedWaveformProps {
+export interface SyncedWaveformProps {
   waveformData: number[];
   audioUrl: string;
   duration?: number;

--- a/packages/frontend/src/components/waveform/SyncedWaveform.tsx
+++ b/packages/frontend/src/components/waveform/SyncedWaveform.tsx
@@ -32,6 +32,7 @@ export function SyncedWaveform({
       color={color}
       progressColor={progressColor}
       isFullTrack={isFullTrack}
+      isStreamable={false}
     />
   );
 }

--- a/packages/frontend/src/components/waveform/TrackListWaveform.tsx
+++ b/packages/frontend/src/components/waveform/TrackListWaveform.tsx
@@ -1,7 +1,7 @@
 import { useTrackListPlayback } from "@/contexts/TrackListPlaybackContext";
 import { WaveformDisplay } from "./WaveformDisplay";
 
-interface TrackListWaveformProps {
+export interface TrackListWaveformProps {
   waveformData: number[];
   audioUrl: string;
   duration?: number;

--- a/packages/frontend/src/components/waveform/WaveformDisplay.tsx
+++ b/packages/frontend/src/components/waveform/WaveformDisplay.tsx
@@ -8,10 +8,12 @@ interface WaveformDisplayProps {
   waveformData: number[];
   audioUrl: string;
   duration?: number;
+  preloadMetadata?: boolean;
   height?: number;
   color?: string;
   progressColor?: string;
   isFullTrack?: boolean;
+  isStreamable?: boolean;
 }
 
 export function WaveformDisplay({
@@ -19,10 +21,12 @@ export function WaveformDisplay({
   waveformData,
   audioUrl,
   duration,
+  preloadMetadata = false,
   height = 128,
   color = "#1f2937",
   progressColor = "#4f46e5",
   isFullTrack = false,
+  isStreamable = false,
 }: WaveformDisplayProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const wavesurferRef = useRef<WaveSurfer | null>(null);
@@ -107,9 +111,13 @@ export function WaveformDisplay({
 
     // Only create if we don't have an instance
     if (!wavesurferRef.current) {
-      audioRef.current = new Audio(audioUrl);
-      audioRef.current.preload = isFullTrack ? "metadata" : "none";
-      audioRef.current.src = audioUrl;
+      if (isStreamable) {
+        audioRef.current = new Audio();
+        audioRef.current.preload = preloadMetadata ? "metadata" : "none";
+        audioRef.current.src = audioUrl;
+      } else {
+        audioRef.current = new Audio(audioUrl);
+      }
 
       const params = {
         container: containerRef.current,
@@ -180,15 +188,18 @@ export function WaveformDisplay({
         }
       }
     };
-  }, []);
+  }, [isStreamable]);
 
   // Update Audio element when props change
   useEffect(() => {
     if (audioRef.current) {
-      audioRef.current.preload = isFullTrack ? "metadata" : "none";
       audioRef.current.src = audioUrl;
+
+      if (!isStreamable) {
+        audioRef.current.preload = preloadMetadata ? "metadata" : "none";
+      }
     }
-  }, [audioUrl, isFullTrack]);
+  }, [audioUrl, preloadMetadata]);
 
   // Update WaveSurfer options when props change
   useEffect(() => {

--- a/packages/frontend/src/components/waveform/WaveformDisplay.tsx
+++ b/packages/frontend/src/components/waveform/WaveformDisplay.tsx
@@ -115,8 +115,6 @@ export function WaveformDisplay({
         audioRef.current = new Audio();
         audioRef.current.preload = preloadMetadata ? "metadata" : "none";
         audioRef.current.src = audioUrl;
-      } else {
-        audioRef.current = new Audio(audioUrl);
       }
 
       const params = {
@@ -135,9 +133,13 @@ export function WaveformDisplay({
         peaks: [new Float32Array(waveformData)],
         duration,
         autoplay: false,
-        media: audioRef.current,
+        ...(isStreamable
+          ? { media: audioRef.current }
+          : {
+              url: audioUrl,
+              backend: "WebAudio" as const,
+            }),
       };
-
       const wavesurfer = WaveSurfer.create(params);
 
       wavesurfer.on("loading", () => {
@@ -188,18 +190,15 @@ export function WaveformDisplay({
         }
       }
     };
-  }, [isStreamable]);
+  }, []);
 
   // Update Audio element when props change
   useEffect(() => {
-    if (audioRef.current) {
+    if (audioRef.current && isStreamable) {
       audioRef.current.src = audioUrl;
-
-      if (!isStreamable) {
-        audioRef.current.preload = preloadMetadata ? "metadata" : "none";
-      }
+      audioRef.current.preload = preloadMetadata ? "metadata" : "none";
     }
-  }, [audioUrl, preloadMetadata]);
+  }, [audioUrl, preloadMetadata, isStreamable]);
 
   // Update WaveSurfer options when props change
   useEffect(() => {

--- a/packages/frontend/src/components/waveform/WaveformDisplay.tsx
+++ b/packages/frontend/src/components/waveform/WaveformDisplay.tsx
@@ -102,6 +102,7 @@ export function WaveformDisplay({
 
   // Initialize WaveSurfer instance
   useEffect(() => {
+    console.log(">>> in useEffect", { audioUrl });
     if (!containerRef.current || !waveformData?.length) return;
 
     // Only create if we don't have an instance
@@ -161,19 +162,24 @@ export function WaveformDisplay({
       });
 
       wavesurferRef.current = wavesurfer;
+    }
 
-      return () => {
+    return () => {
+      // Only clean up if we are actually unmounting
+      if (!document.contains(containerRef.current!)) {
         if (audioRef.current) {
           audioRef.current.pause();
           audioRef.current.src = "";
           audioRef.current.load();
         }
 
-        unregisterWaveform(wavesurfer);
-        wavesurfer.destroy();
-        wavesurferRef.current = null;
-      };
-    }
+        if (wavesurferRef.current) {
+          unregisterWaveform(wavesurferRef.current!);
+          wavesurferRef.current.destroy();
+          wavesurferRef.current = null;
+        }
+      }
+    };
   }, []);
 
   // Update Audio element when props change

--- a/packages/frontend/src/pages/TrackDetails/components/TrackDetailsWaveform.tsx
+++ b/packages/frontend/src/pages/TrackDetails/components/TrackDetailsWaveform.tsx
@@ -1,7 +1,7 @@
 import {
-  TrackListWaveform,
-  TrackListWaveformProps,
-} from "@/components/waveform/TrackListWaveform";
+  StreamableWaveform,
+  StreamableWaveformProps,
+} from "@/components/waveform/StreamableWaveform";
 import {
   SyncedWaveform,
   SyncedWaveformProps,
@@ -9,7 +9,7 @@ import {
 import { PlaybackContext } from "../contexts/PlaybackContext";
 import { useContext } from "react";
 
-export type TrackDetailsWaveformProps = TrackListWaveformProps &
+export type TrackDetailsWaveformProps = StreamableWaveformProps &
   SyncedWaveformProps;
 
 export function TrackDetailsWaveform({
@@ -28,7 +28,7 @@ export function TrackDetailsWaveform({
   }
 
   return playbackContext.playMode === "preview" ? (
-    <TrackListWaveform
+    <StreamableWaveform
       waveformData={waveformData}
       audioUrl={audioUrl}
       duration={duration}

--- a/packages/frontend/src/pages/TrackDetails/components/TrackDetailsWaveform.tsx
+++ b/packages/frontend/src/pages/TrackDetails/components/TrackDetailsWaveform.tsx
@@ -1,0 +1,50 @@
+import {
+  TrackListWaveform,
+  TrackListWaveformProps,
+} from "@/components/waveform/TrackListWaveform";
+import {
+  SyncedWaveform,
+  SyncedWaveformProps,
+} from "@/components/waveform/SyncedWaveform";
+import { PlaybackContext } from "../contexts/PlaybackContext";
+import { useContext } from "react";
+
+export type TrackDetailsWaveformProps = TrackListWaveformProps &
+  SyncedWaveformProps;
+
+export function TrackDetailsWaveform({
+  waveformData,
+  audioUrl,
+  duration,
+  height,
+  color,
+  progressColor,
+  isFullTrack,
+}: TrackDetailsWaveformProps) {
+  const playbackContext = useContext(PlaybackContext);
+
+  if (!playbackContext) {
+    return null;
+  }
+
+  return playbackContext.playMode === "preview" ? (
+    <TrackListWaveform
+      waveformData={waveformData}
+      audioUrl={audioUrl}
+      duration={duration}
+      height={height}
+      color={color}
+      progressColor={progressColor}
+    />
+  ) : (
+    <SyncedWaveform
+      waveformData={waveformData}
+      audioUrl={audioUrl}
+      duration={duration}
+      height={height}
+      color={color}
+      progressColor={progressColor}
+      isFullTrack={isFullTrack}
+    />
+  );
+}

--- a/packages/frontend/src/pages/TrackDetails/contexts/PlaybackContext.tsx
+++ b/packages/frontend/src/pages/TrackDetails/contexts/PlaybackContext.tsx
@@ -1,0 +1,29 @@
+import { SyncedPlaybackProvider } from "@/contexts/SyncedPlaybackContext";
+import { TrackListPlaybackProvider } from "@/contexts/TrackListPlaybackContext";
+import { createContext, useState, ReactNode } from "react";
+
+export type PlayMode = "preview" | "sync";
+
+export interface PlaybackContextType {
+  playMode: PlayMode;
+  setPlayMode: (playMode: PlayMode) => void;
+}
+
+export const PlaybackContext = createContext<PlaybackContextType | null>(null);
+
+export function TrackDetailsPlaybackProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [playMode, setPlayMode] = useState<PlayMode>("preview");
+
+  const PlaybackProvider =
+    playMode === "preview" ? TrackListPlaybackProvider : SyncedPlaybackProvider;
+
+  return (
+    <PlaybackContext.Provider value={{ playMode, setPlayMode }}>
+      <PlaybackProvider>{children}</PlaybackProvider>
+    </PlaybackContext.Provider>
+  );
+}

--- a/packages/frontend/src/pages/TrackDetails/index.tsx
+++ b/packages/frontend/src/pages/TrackDetails/index.tsx
@@ -1,20 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { useState } from "react";
-import { SyncedPlaybackProvider } from "../contexts/SyncedPlaybackContext";
-import { useAuthToken } from "../hooks/useAuthToken";
-import { TrackHeader } from "../components/track-details/TrackHeader";
-import { FullTrackSection } from "../components/track-details/FullTrackSection";
-import { ComponentsSection } from "../components/track-details/ComponentsSection";
-import { ViewMode } from "../components/track-details/ViewModeToggle";
-import { LoadingState } from "../components/ui/LoadingState";
-import { ErrorState } from "../components/ui/ErrorState";
-import { api } from "../api/client";
-import { TrackSharingControls } from "../components/track-details/TrackSharingControls";
+import { useAuthToken } from "../../hooks/useAuthToken";
+import { TrackHeader } from "../../components/track-details/TrackHeader";
+import { FullTrackSection } from "../../components/track-details/FullTrackSection";
+import { ComponentsSection } from "../../components/track-details/ComponentsSection";
+import { ViewMode } from "../../components/track-details/ViewModeToggle";
+import { LoadingState } from "../../components/ui/LoadingState";
+import { ErrorState } from "../../components/ui/ErrorState";
+import { api } from "../../api/client";
+import { TrackSharingControls } from "../../components/track-details/TrackSharingControls";
 import { useAuth } from "@/contexts/AuthContext";
+import { TrackDetailsPlaybackProvider } from "./contexts/PlaybackContext";
 
 export function TrackDetails() {
   const { id } = useParams<{ id: string }>();
+  // TODO: Move viewMode state to ComponentsSection if it's only used there
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const { getToken } = useAuthToken();
   const { user } = useAuth();
@@ -46,7 +47,7 @@ export function TrackDetails() {
   }
 
   return (
-    <SyncedPlaybackProvider>
+    <TrackDetailsPlaybackProvider>
       <div>
         <TrackHeader
           title={track.title}
@@ -67,6 +68,6 @@ export function TrackDetails() {
           <TrackSharingControls track={track} token={token} />
         )}
       </div>
-    </SyncedPlaybackProvider>
+    </TrackDetailsPlaybackProvider>
   );
 }


### PR DESCRIPTION
This PR introduces a new playback mode toggle feature that allows users to switch between preview and sync modes when playing tracks. Key changes include:

- Added new PlayModeToggle component with preview/sync options
- Created TrackDetailsPlaybackProvider to manage playback mode state
- Refactored waveform components to support both streaming and synced playback
- Improved waveform initialization and cleanup logic
- Added new Toggle UI component for consistent toggle styling
- Updated track details page to use new playback context
- Removed unnecessary cache-control header for track downloads

The changes improve the user experience by providing more control over how tracks are played while also cleaning up the underlying playback architecture.