### PR TITLE
Add support for .it and .mod tracker formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,6 @@ coverage
 *.flac
 *.wav
 *.xm
+*.it
+*.mod
 uploads/ 

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = packages/media/deps/milkytracker
 	url = https://github.com/trh-x/MilkyTracker.git
 	branch = trh/export-to-wav
+[submodule "packages/media/deps/schismtracker"]
+	path = packages/media/deps/schismtracker
+	url = https://github.com/schismtracker/schismtracker.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = packages/media/deps/milkytracker
 	url = https://github.com/trh-x/MilkyTracker.git
 	branch = trh/export-to-wav
-[submodule "packages/media/deps/schismtracker"]
-	path = packages/media/deps/schismtracker
-	url = https://github.com/schismtracker/schismtracker.git

--- a/README.md
+++ b/README.md
@@ -51,18 +51,32 @@ git clone --recursive https://github.com/your-repo/wavtopia.git
 # If you've already cloned the repository:
 git submodule update --init --recursive
 
-# Pulling MilkyTracker changes into this repo:
+# Pulling dependency changes into this repo:
 git submodule update --remote
-git add packages/media/deps/milkytracker && git commit
+git add packages/media/deps/milkytracker packages/media/deps/schismtracker && git commit
 ```
 
-The media service's Dockerfile will automatically build and install the `milkycli` utility during container build.
+The media service's Dockerfile will automatically build and install both the `milkycli` utility and Schism Tracker during container build.
 
-Note: This is a temporary requirement until [PR #372](https://github.com/milkytracker/MilkyTracker/pull/372) is merged into MilkyTracker's main branch.
+Note: MilkyTracker submodule is a temporary requirement until [PR #372](https://github.com/milkytracker/MilkyTracker/pull/372) is merged into MilkyTracker's main branch.
 
 ### `schismtracker` Installation
 
-TODO: Add instructions for installing schismtracker
+Schism Tracker is used for additional module file format support and conversion. The media service's Docker image builds Schism Tracker from source to support multiple architectures.
+
+For local development, you can install it:
+
+```bash
+# Build from source (same as Docker)
+git clone https://github.com/schismtracker/schismtracker.git
+cd schismtracker
+git checkout 20250208
+autoreconf -i
+mkdir -p build && cd build
+../configure
+make
+sudo cp schismtracker /usr/local/bin/
+```
 
 ### Installation Steps
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ A modern web platform for sharing and downloading multi-track music files. Wavto
 - FFmpeg
 - libxmp
 - MinIO (for local development) or S3-compatible storage
-- export-to-wav utility (see below)
+- milkycli utility (see below)
 
-### export-to-wav Installation
+### `milkycli` Installation
 
-The project requires the `export-to-wav` utility from MilkyTracker for converting XM files to WAV format. This utility is included as a git submodule from [this open pull request](https://github.com/milkytracker/MilkyTracker/pull/372).
+The project requires the `milkycli` utility from MilkyTracker for converting XM files to WAV format. This utility is included as a git submodule from [this open pull request](https://github.com/milkytracker/MilkyTracker/pull/372).
 
 When cloning the repository, make sure to initialize the submodules:
 
@@ -55,7 +55,7 @@ git submodule update --remote
 git add packages/media/deps/milkytracker && git commit
 ```
 
-The media service's Dockerfile will automatically build and install the `export-to-wav` utility during container build.
+The media service's Dockerfile will automatically build and install the `milkycli` utility during container build.
 
 Note: This is a temporary requirement until [PR #372](https://github.com/milkytracker/MilkyTracker/pull/372) is merged into MilkyTracker's main branch.
 
@@ -272,7 +272,7 @@ MINIO_PORT="9000"
 MINIO_ROOT_USER="minioadmin"
 MINIO_ROOT_PASSWORD="minioadmin"
 MINIO_BUCKET="wavtopia"
-EXPORT_TO_WAV_PATH="/usr/local/bin/export-to-wav"
+MILKYCLI_PATH="/usr/local/bin/milkycli"
 
 # packages/frontend/.env
 VITE_API_URL="http://localhost:3002"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ A modern web platform for sharing and downloading multi-track music files. Wavto
 ## Features
 
 - **Track Management**: Upload, manage, and share your music tracks
-- **Audio Conversion**: Automatic conversion of .xm files to WAV format
+- **Audio Conversion**: Automatic conversion of .xm, .it, and .mod files to WAV format
 - **Component Extraction**: Split tracks into individual instrument components
 - **Multi-format Downloads**:
-  - Download the original tracker file (.xm)
+  - Download the original tracker file (.xm, .it, .mod)
   - Download the full track as WAV
   - Download individual instrument components as WAV
 - **Real-time Playback**: Play and preview tracks directly in the browser
@@ -36,6 +36,7 @@ A modern web platform for sharing and downloading multi-track music files. Wavto
 - libxmp
 - MinIO (for local development) or S3-compatible storage
 - milkycli utility (see below)
+- schismtracker application (see below)
 
 ### `milkycli` Installation
 
@@ -58,6 +59,10 @@ git add packages/media/deps/milkytracker && git commit
 The media service's Dockerfile will automatically build and install the `milkycli` utility during container build.
 
 Note: This is a temporary requirement until [PR #372](https://github.com/milkytracker/MilkyTracker/pull/372) is merged into MilkyTracker's main branch.
+
+### `schismtracker` Installation
+
+TODO: Add instructions for installing schismtracker
 
 ### Installation Steps
 
@@ -227,7 +232,7 @@ The backend provides the following main endpoints:
 - `GET /api/track/:id` - Get track details
 - `PATCH /api/track/:id` - Update track details
 - `DELETE /api/track/:id` - Delete a track
-- `GET /api/track/:id/original` - Download original .xm file
+- `GET /api/track/:id/original` - Download file in original format
 - `GET /api/track/:id/full` - Download full track WAV
 - `GET /api/track/:id/component/:componentId` - Download component WAV
 
@@ -250,7 +255,7 @@ The backend provides the following main endpoints:
 
 2. **File upload fails**
 
-   - Check that your file is in .xm format
+   - Check that your file is in a supported format (xm, it, mod)
    - Ensure the file size is under 50MB
    - Verify MinIO is running and accessible
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,10 +61,6 @@ services:
       context: .
       dockerfile: Dockerfile
     image: ${REGISTRY_PREFIX:-}wavtopia-workspace
-    depends_on:
-      - condition: service_completed_successfully
-        service: tools
-        required: false
 
   media:
     profiles:
@@ -84,6 +80,8 @@ services:
       - wavtopia-net
     depends_on:
       workspace:
+        condition: service_completed_successfully
+      tools:
         condition: service_completed_successfully
       minio:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,10 +79,6 @@ services:
     networks:
       - wavtopia-net
     depends_on:
-      workspace:
-        condition: service_completed_successfully
-      tools:
-        condition: service_completed_successfully
       minio:
         condition: service_started
       redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,9 @@ services:
       dockerfile: Dockerfile
     image: ${REGISTRY_PREFIX:-}wavtopia-workspace
     depends_on:
-      tools:
-        condition: service_completed_successfully
+      - condition: service_completed_successfully
+        service: tools
+        required: false
 
   media:
     profiles:
@@ -83,8 +84,6 @@ services:
       - wavtopia-net
     depends_on:
       workspace:
-        condition: service_completed_successfully
-      tools:
         condition: service_completed_successfully
       minio:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,15 @@ services:
     networks:
       - wavtopia-net
 
+  tools:
+    profiles:
+      - build
+      - production
+    build:
+      context: packages/media
+      dockerfile: Dockerfile.tools
+    image: ${REGISTRY_PREFIX:-}wavtopia-tools
+
   workspace:
     profiles:
       - build
@@ -53,13 +62,16 @@ services:
       context: .
       dockerfile: Dockerfile
     image: ${REGISTRY_PREFIX:-}wavtopia-workspace
+    depends_on:
+      tools:
+        condition: service_completed_successfully
 
   media:
     profiles:
       - production
     build:
-      context: .
-      dockerfile: packages/media/Dockerfile
+      context: packages/media
+      dockerfile: Dockerfile
       args:
         - WORKSPACE_IMAGE=${REGISTRY_PREFIX:-}wavtopia-workspace
     image: ${REGISTRY_PREFIX:-}wavtopia-media
@@ -72,6 +84,8 @@ services:
       - wavtopia-net
     depends_on:
       workspace:
+        condition: service_completed_successfully
+      tools:
         condition: service_completed_successfully
       minio:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
   tools:
     profiles:
       - build
-      - production
     build:
       context: packages/media
       dockerfile: Dockerfile.tools

--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -84,6 +84,8 @@ This document provides tips and common solutions for debugging issues in the Wav
      "Starting track upload process..."
      "Uploading original file..."
      "Converting XM to WAV..."
+     "Converting IT to WAV..."
+     "Converting MOD to WAV..."
      "Generating waveform data..."
      "Converting to MP3..."
      ```

--- a/packages/backend/src/middleware/upload.ts
+++ b/packages/backend/src/middleware/upload.ts
@@ -22,14 +22,21 @@ const upload = multer({
     fileSize: 50 * 1024 * 1024, // 50MB limit
   },
   fileFilter: (req, file, cb) => {
-    // Accept .xm files (case-insensitive) and images for cover art
+    // Accept .xm, .it, and .mod files (case-insensitive) and images for cover art
     if (
       file.originalname.toLowerCase().endsWith(".xm") ||
+      file.originalname.toLowerCase().endsWith(".it") ||
+      file.originalname.toLowerCase().endsWith(".mod") ||
       file.mimetype.startsWith("image/")
     ) {
       cb(null, true);
     } else {
-      cb(new AppError(400, "Only .xm files and images are allowed"));
+      cb(
+        new AppError(
+          400,
+          "Only .xm, .it, and .mod files and images are allowed"
+        )
+      );
     }
   },
 });

--- a/packages/backend/src/routes/track.ts
+++ b/packages/backend/src/routes/track.ts
@@ -23,6 +23,7 @@ const router = Router();
 const trackSchema = z.object({
   title: z.string().min(1),
   artist: z.string().min(1),
+  // TODO: originalFormat: z.nativeEnum(SourceFormat),
   originalFormat: z.string().min(1),
   metadata: z.record(z.unknown()).optional(),
   isPublic: z.boolean().optional(),

--- a/packages/backend/src/routes/track.ts
+++ b/packages/backend/src/routes/track.ts
@@ -120,23 +120,9 @@ const authenticateTrackAccess: RequestHandler = async (
       return next(new AppError(404, "Track not found"));
     }
 
-    // Only allow access to certain fields for public tracks when user is not authenticated
+    // Omit some fields for public tracks when user is not authenticated
     if (reqTrack.isPublic && !req.user) {
-      const publicTrack = {
-        id: reqTrack.id,
-        title: reqTrack.title,
-        artist: reqTrack.artist,
-        coverArt: reqTrack.coverArt,
-        isPublic: reqTrack.isPublic,
-        fullTrackWavUrl: reqTrack.fullTrackWavUrl,
-        fullTrackMp3Url: reqTrack.fullTrackMp3Url,
-        originalFormat: reqTrack.originalFormat,
-        waveformData: reqTrack.waveformData,
-        components: reqTrack.components,
-        user: reqTrack.user,
-        createdAt: reqTrack.createdAt,
-        updatedAt: reqTrack.updatedAt,
-      };
+      const { sharedWith, ...publicTrack } = reqTrack;
       (req as any).track = publicTrack; // TODO: Fix this `any`
     } else {
       (req as any).track = reqTrack; // TODO: Fix this `any`

--- a/packages/core-storage/prisma/migrations/20250209214718_add_source_format_enum/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250209214718_add_source_format_enum/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Changed the type of `original_format` on the `tracks` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- CreateEnum
+CREATE TYPE "SourceFormat" AS ENUM ('xm', 'it');
+
+-- AlterTable
+ALTER TABLE "tracks" ALTER COLUMN "original_format" TYPE "SourceFormat" USING "original_format"::text::"SourceFormat";

--- a/packages/core-storage/prisma/migrations/20250209221208_add_mod_format/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250209221208_add_mod_format/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SourceFormat" ADD VALUE 'mod';

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -31,13 +31,18 @@ enum Role {
   ADMIN
 }
 
+enum SourceFormat {
+  XM  @map("xm")  // FastTracker2
+  IT  @map("it")  // Impulse Tracker
+}
+
 // TODO: The Url suffixes should be removed/replaced, as the values stored are not URLs (with
 // the exception of originalUrl, which is a file:// URL until the track is converted).
 model Track {
   id               String       @id @default(uuid())
   title            String
   artist           String
-  originalFormat   String       @map("original_format") // TODO: Define enum for formats
+  originalFormat   SourceFormat @map("original_format")
   originalUrl      String       @map("original_url")
   fullTrackWavUrl  String?      @map("full_track_wav_url")
   fullTrackMp3Url  String?      @map("full_track_mp3_url")

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -34,6 +34,7 @@ enum Role {
 enum SourceFormat {
   XM  @map("xm")  // FastTracker2
   IT  @map("it")  // Impulse Tracker
+  MOD @map("mod") // ProTracker/NoiseTracker
 }
 
 // TODO: The Url suffixes should be removed/replaced, as the values stored are not URLs (with

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -18,6 +18,7 @@ export {
   Prisma,
   User,
   Role,
+  SourceFormat,
   InviteCode,
   FeatureFlag,
   Notification,

--- a/packages/core-storage/types/index.d.ts
+++ b/packages/core-storage/types/index.d.ts
@@ -2,6 +2,6 @@ export { StorageService, type StorageFile } from "./services/storage";
 export { PrismaService } from "./services/prisma";
 export { deleteLocalFile, ensureDirectoryExists, normalizeFilePath, } from "./services/local-storage";
 export { config, type StorageConfig, type DatabaseConfig, type RedisConfig, type SharedConfig, } from "./config";
-export { Prisma, User, Role, InviteCode, FeatureFlag, Notification, NotificationType, AudioFileConversionStatus, } from ".prisma/client";
+export { Prisma, User, Role, SourceFormat, InviteCode, FeatureFlag, Notification, NotificationType, AudioFileConversionStatus, } from ".prisma/client";
 export { type Track, type Component, type TrackShare, type PaginatedResponse, type PaginationParams, encodeCursor, decodeCursor, } from "./types";
 export * from "./auth";

--- a/packages/frontend/src/pages/BulkUploadTrack/components/DropZone.tsx
+++ b/packages/frontend/src/pages/BulkUploadTrack/components/DropZone.tsx
@@ -49,13 +49,13 @@ export function DropZone({
         type="file"
         className="hidden"
         multiple
-        accept=".xm,image/*"
+        accept=".xm,.it,.mod,image/*"
         onChange={handleFileSelect}
         disabled={disabled}
       />
       <div className="space-y-2">
         <p className="text-lg font-medium">
-          Drop track files (.xm) and cover art here
+          Drop track files (.xm, .it, .mod) and cover art here
         </p>
         <p className="text-sm text-gray-500">or click to select files</p>
       </div>

--- a/packages/frontend/src/pages/BulkUploadTrack/hooks/useFileProcessing.ts
+++ b/packages/frontend/src/pages/BulkUploadTrack/hooks/useFileProcessing.ts
@@ -128,6 +128,12 @@ export function useFileProcessing(getToken: () => string | null) {
         `Uploading track ${i + 1}/${pendingUploads.length}: ${match.title}`
       );
 
+      const originalFormat = match.track.name.split(".").pop()?.toLowerCase();
+      if (!originalFormat) {
+        console.error(`No original format found for ${match.title}`);
+        continue;
+      }
+
       try {
         const formData = new FormData();
         formData.append(
@@ -135,7 +141,7 @@ export function useFileProcessing(getToken: () => string | null) {
           JSON.stringify({
             title: match.title,
             artist: state.defaultArtist.trim() || "Unknown Artist",
-            originalFormat: "xm",
+            originalFormat,
           })
         );
 

--- a/packages/frontend/src/pages/BulkUploadTrack/utils/fileMatching.ts
+++ b/packages/frontend/src/pages/BulkUploadTrack/utils/fileMatching.ts
@@ -38,7 +38,10 @@ export function processFiles(
     const ext = file.name.split(".").pop()?.toLowerCase();
     const baseName = file.name.substring(0, file.name.lastIndexOf("."));
 
-    if (ext === "xm" && !existingPaths.has(file.name)) {
+    if (
+      (ext === "xm" || ext === "it" || ext === "mod") &&
+      !existingPaths.has(file.name)
+    ) {
       trackFiles.set(baseName, file);
     } else if (
       file.type.startsWith("image/") &&

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -7,7 +7,7 @@ import { api } from "@/api/client";
 interface UploadFormData {
   title: string;
   artist: string;
-  originalFormat: string;
+  originalFormat: string | null;
   original: File | null;
   coverArt: File | null;
 }
@@ -21,7 +21,7 @@ export function UploadTrack() {
       initialValues: {
         title: "",
         artist: "",
-        originalFormat: "xm",
+        originalFormat: null,
         original: null,
         coverArt: null,
       },
@@ -55,8 +55,14 @@ export function UploadTrack() {
   ) => {
     const file = e.target.files?.[0] || null;
     if (file && field === "original") {
-      const format = file.name.split(".").pop()?.toLowerCase() || "xm";
-      handleChange("originalFormat", format);
+      const format = file.name.split(".").pop()?.toLowerCase();
+      if (format === "it") {
+        handleChange("originalFormat", "it");
+      } else if (format === "mod") {
+        handleChange("originalFormat", "mod");
+      } else {
+        handleChange("originalFormat", "xm");
+      }
     }
     handleChange(field, file);
   };
@@ -89,9 +95,9 @@ export function UploadTrack() {
           <FormInput
             id="original"
             type="file"
-            label="Original Track File (.xm or .XM)"
+            label="Original Track File (.xm, .it, .mod)"
             required
-            accept=".xm,.XM"
+            accept=".xm,.it,.mod"
             onChange={(e) => handleFileChange(e, "original")}
           />
 

--- a/packages/media/Dockerfile
+++ b/packages/media/Dockerfile
@@ -22,14 +22,14 @@ RUN apt-get update && \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Build export-to-wav utility
+# Build milkycli utility
 COPY packages/media/deps/milkytracker ./deps/milkytracker
 
 # Build MilkyTracker
 RUN cd deps/milkytracker && \
     cmake -B build -DCMAKE_BUILD_TYPE=Release && \
-    cmake --build build --target export-to-wav && \
-    cp build/src/tools/export-to-wav/export-to-wav /usr/local/bin/ && \
+    cmake --build build --target milkycli && \
+    cp build/src/tools/milkycli/milkycli /usr/local/bin/ && \
     cd ../.. && \
     rm -rf deps/milkytracker
 

--- a/packages/media/Dockerfile
+++ b/packages/media/Dockerfile
@@ -13,14 +13,36 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ffmpeg \
     lame \
+    # MilkyTracker dependencies
     build-essential \
     cmake \
     libsdl2-dev \
     libjack-dev \
     librtmidi-dev \
     zlib1g-dev \
+    # Schism Tracker dependencies
+    automake \
+    autoconf-archive \
+    libtool \
+    libflac-dev \
+    perl \
+    pkgconf \
+    libutf8proc-dev \
+    # Clean up
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Build and install Schism Tracker from source
+COPY packages/media/deps/schismtracker ./deps/schismtracker
+RUN cd deps/schismtracker && \
+    autoreconf -i && \
+    mkdir -p build && \
+    cd build && \
+    ../configure && \
+    make && \
+    cp schismtracker /usr/local/bin/ && \
+    cd ../.. && \
+    rm -rf deps/schismtracker
 
 # Build milkycli utility
 COPY packages/media/deps/milkytracker ./deps/milkytracker

--- a/packages/media/Dockerfile
+++ b/packages/media/Dockerfile
@@ -1,5 +1,10 @@
 # Get the workspace image name from build args
 ARG WORKSPACE_IMAGE
+
+# Build the tools image first
+FROM wavtopia-tools AS tools
+
+# Use workspace image for building the service
 FROM ${WORKSPACE_IMAGE} AS prod-build
 
 # Create deployment for media service
@@ -8,52 +13,21 @@ RUN pnpm --filter @wavtopia/media --prod deploy media-service
 # Create the final image
 FROM node:18-slim
 
-# Install FFmpeg and build dependencies
+# Install runtime dependencies only
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ffmpeg \
     lame \
-    # MilkyTracker dependencies
-    build-essential \
-    cmake \
-    libsdl2-dev \
-    libjack-dev \
-    librtmidi-dev \
-    zlib1g-dev \
     # Schism Tracker dependencies
-    automake \
-    autoconf-archive \
-    libtool \
-    libflac-dev \
-    perl \
-    pkgconf \
-    libutf8proc-dev \
+    libjack0 \
+    libutf8proc2 \
     # Clean up
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Build and install Schism Tracker from source
-COPY packages/media/deps/schismtracker ./deps/schismtracker
-RUN cd deps/schismtracker && \
-    autoreconf -i && \
-    mkdir -p build && \
-    cd build && \
-    ../configure --with-alsa=no && \
-    make && \
-    cp schismtracker /usr/local/bin/ && \
-    cd ../.. && \
-    rm -rf deps/schismtracker
-
-# Build milkycli utility
-COPY packages/media/deps/milkytracker ./deps/milkytracker
-
-# Build MilkyTracker
-RUN cd deps/milkytracker && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Release && \
-    cmake --build build --target milkycli && \
-    cp build/src/tools/milkycli/milkycli /usr/local/bin/ && \
-    cd ../.. && \
-    rm -rf deps/milkytracker
+# Copy the compiled tools from the tools image
+COPY --from=tools /usr/local/bin/schismtracker /usr/local/bin/
+COPY --from=tools /usr/local/bin/milkycli /usr/local/bin/
 
 WORKDIR /app
 
@@ -63,21 +37,21 @@ COPY --from=prod-build /app/media-service .
 # Create directories for file processing
 RUN mkdir -p /tmp/uploads /tmp/converted && \
     chmod 775 /tmp/uploads /tmp/converted && \
-    # Create XDG runtime directory
+    # Create XDG runtime directory for schismtracker
     mkdir -p /run/user/1000 && \
     chmod 700 /run/user/1000 && \
     # Create schismtracker config directory
     mkdir -p /root/.config/schism
 
 # Copy schismtracker config
-COPY packages/media/config/schism/config /root/.config/schism/config
+COPY config/schism/config /root/.config/schism/config
 
-# Set environment variables
+# Set environment variables for schismtracker
 ENV XDG_RUNTIME_DIR=/run/user/1000
 ENV SDL_AUDIODRIVER=disk
 
 # Copy env file for the media service
-COPY packages/media/.env.docker .env
+COPY .env.docker .env
 
 ENV NODE_ENV=production
 

--- a/packages/media/Dockerfile
+++ b/packages/media/Dockerfile
@@ -38,7 +38,7 @@ RUN cd deps/schismtracker && \
     autoreconf -i && \
     mkdir -p build && \
     cd build && \
-    ../configure && \
+    ../configure --with-alsa=no && \
     make && \
     cp schismtracker /usr/local/bin/ && \
     cd ../.. && \
@@ -62,7 +62,19 @@ COPY --from=prod-build /app/media-service .
 
 # Create directories for file processing
 RUN mkdir -p /tmp/uploads /tmp/converted && \
-    chmod 775 /tmp/uploads /tmp/converted
+    chmod 775 /tmp/uploads /tmp/converted && \
+    # Create XDG runtime directory
+    mkdir -p /run/user/1000 && \
+    chmod 700 /run/user/1000 && \
+    # Create schismtracker config directory
+    mkdir -p /root/.config/schism
+
+# Copy schismtracker config
+COPY packages/media/config/schism/config /root/.config/schism/config
+
+# Set environment variables
+ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV SDL_AUDIODRIVER=disk
 
 # Copy env file for the media service
 COPY packages/media/.env.docker .env

--- a/packages/media/Dockerfile.tools
+++ b/packages/media/Dockerfile.tools
@@ -1,0 +1,46 @@
+FROM node:18-slim
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    # MilkyTracker dependencies
+    build-essential \
+    cmake \
+    libsdl2-dev \
+    libjack-dev \
+    librtmidi-dev \
+    zlib1g-dev \
+    # Schism Tracker dependencies
+    automake \
+    autoconf-archive \
+    libtool \
+    libflac-dev \
+    perl \
+    pkgconf \
+    libutf8proc-dev \
+    # Clean up
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build and install Schism Tracker from source
+COPY deps/schismtracker ./deps/schismtracker
+RUN cd deps/schismtracker && \
+    autoreconf -i && \
+    mkdir -p build && \
+    cd build && \
+    ../configure --with-alsa=no && \
+    make && \
+    cp schismtracker /usr/local/bin/ && \
+    cd ../.. && \
+    rm -rf deps/schismtracker
+
+# Build milkycli utility
+COPY deps/milkytracker ./deps/milkytracker
+
+# Build MilkyTracker
+RUN cd deps/milkytracker && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build --target milkycli && \
+    cp build/src/tools/milkycli/milkycli /usr/local/bin/ && \
+    cd ../.. && \
+    rm -rf deps/milkytracker 

--- a/packages/media/config/schism/config
+++ b/packages/media/config/schism/config
@@ -1,0 +1,12 @@
+[Audio]
+driver=disk
+bits=16
+channels=2
+# Specify 44100 as the sample rate, matching the default for MilkyTracker. SchismTracker defaults to 48000.
+sample_rate=44100
+buffer_size=1024
+
+[Mixer Settings]
+channel_limit=128
+interpolation_mode=1
+surround_effect=1 

--- a/packages/media/src/config.ts
+++ b/packages/media/src/config.ts
@@ -8,6 +8,7 @@ export const ServerConfigSchema = z.object({
 
 export const ToolsConfigSchema = z.object({
   milkyCliPath: z.string().default("/usr/local/bin/milkycli"),
+  schismTrackerPath: z.string().default("/usr/local/bin/schismtracker"),
 });
 
 export const SharedConfigSchema = z.object({
@@ -26,6 +27,7 @@ function loadConfig(): SharedConfig {
     },
     tools: {
       milkyCliPath: process.env.MILKYCLI_PATH,
+      schismTrackerPath: process.env.SCHISMTRACKER_PATH,
     },
   });
 }

--- a/packages/media/src/config.ts
+++ b/packages/media/src/config.ts
@@ -7,7 +7,7 @@ export const ServerConfigSchema = z.object({
 });
 
 export const ToolsConfigSchema = z.object({
-  exportToWavPath: z.string().default("/usr/local/bin/export-to-wav"),
+  milkyCliPath: z.string().default("/usr/local/bin/milkycli"),
 });
 
 export const SharedConfigSchema = z.object({
@@ -25,7 +25,7 @@ function loadConfig(): SharedConfig {
       jwtSecret: process.env.JWT_SECRET || "your-secret-key",
     },
     tools: {
-      exportToWavPath: process.env.EXPORT_TO_WAV_PATH,
+      milkyCliPath: process.env.MILKYCLI_PATH,
     },
   });
 }

--- a/packages/media/src/routes/media.ts
+++ b/packages/media/src/routes/media.ts
@@ -28,7 +28,7 @@ const audioFileConversionOptionsSchema = z.object({
   format: z.enum(["wav", "flac"]),
 });
 
-// Convert XM file to MP3/FLAC format
+// Convert track module file to MP3/FLAC format
 router.post("/convert-module", async (req, res, next) => {
   try {
     // Parse conversion options

--- a/packages/media/src/services/module-converter.ts
+++ b/packages/media/src/services/module-converter.ts
@@ -36,7 +36,7 @@ export async function convertXMToWAV(
 
       // First, convert the full track
       const { stderr: fullTrackStderr } = await execAsync(
-        `"${config.tools.exportToWavPath}" "${xmPath}" -output "${join(
+        `"${config.tools.milkyCliPath}" "${xmPath}" -output "${join(
           tempDir,
           fullTrackOutput
         )}"`
@@ -53,7 +53,7 @@ export async function convertXMToWAV(
 
       // Then convert individual components
       const { stderr: componentsStderr } = await execAsync(
-        `"${config.tools.exportToWavPath}" "${xmPath}" -output "${join(
+        `"${config.tools.milkyCliPath}" "${xmPath}" -output "${join(
           tempDir,
           componentsBaseName
         )}" -multi-track`

--- a/packages/media/src/services/module-converter.ts
+++ b/packages/media/src/services/module-converter.ts
@@ -27,14 +27,28 @@ async function convertFullTrack(
   tempDir: string,
   fullTrackOutput: string
 ): Promise<{ stdout: string; stderr: string }> {
-  // TODO: Covnert it and mod formats
-  const { stdout, stderr } = await execAsync(
-    `"${config.tools.milkyCliPath}" "${modulePath}" -output "${join(
-      tempDir,
-      fullTrackOutput
-    )}"`
-  );
-  return { stdout, stderr };
+  // TODO: Try libxmp for mod files
+  if (moduleFormat === SourceFormat.XM || moduleFormat === SourceFormat.MOD) {
+    const { stdout, stderr } = await execAsync(
+      `"${config.tools.milkyCliPath}" "${modulePath}" -output "${join(
+        tempDir,
+        fullTrackOutput
+      )}"`
+    );
+    return { stdout, stderr };
+  }
+
+  if (moduleFormat === SourceFormat.IT) {
+    const { stdout, stderr } = await execAsync(
+      `"${config.tools.schismTrackerPath}" --headless --diskwrite="${join(
+        tempDir,
+        fullTrackOutput
+      )}" "${modulePath}"`
+    );
+    return { stdout, stderr };
+  }
+
+  throw new AppError(500, `Unsupported module format: ${moduleFormat}`);
 }
 
 async function convertComponents(
@@ -43,14 +57,28 @@ async function convertComponents(
   tempDir: string,
   componentsBaseName: string
 ): Promise<{ stdout: string; stderr: string }> {
-  // TODO: Convert it and mod formats
-  const { stdout, stderr } = await execAsync(
-    `"${config.tools.milkyCliPath}" "${modulePath}" -output "${join(
-      tempDir,
-      componentsBaseName
-    )}" -multi-track`
-  );
-  return { stdout, stderr };
+  // TODO: Try libxmp for mod files
+  if (moduleFormat === SourceFormat.XM || moduleFormat === SourceFormat.MOD) {
+    const { stdout, stderr } = await execAsync(
+      `"${config.tools.milkyCliPath}" "${modulePath}" -output "${join(
+        tempDir,
+        componentsBaseName
+      )}" -multi-track`
+    );
+    return { stdout, stderr };
+  }
+
+  if (moduleFormat === SourceFormat.IT) {
+    const { stdout, stderr } = await execAsync(
+      `"${config.tools.schismTrackerPath}" --headless --diskwrite="${join(
+        tempDir,
+        componentsBaseName.replace(".wav", "_%c.wav")
+      )}" "${modulePath}"`
+    );
+    return { stdout, stderr };
+  }
+
+  throw new AppError(500, `Unsupported module format: ${moduleFormat}`);
 }
 
 export async function convertModuleToWAV(

--- a/packages/media/src/services/module-converter.ts
+++ b/packages/media/src/services/module-converter.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { AppError } from "../middleware/errorHandler";
 import { config } from "../config";
+import { SourceFormat } from "@wavtopia/core-storage";
 
 const execAsync = promisify(exec);
 
@@ -20,26 +21,61 @@ interface ConversionResult {
   components: ConvertedComponent[];
 }
 
-export async function convertXMToWAV(
-  xmBuffer: Buffer
+async function convertFullTrack(
+  moduleFormat: SourceFormat,
+  modulePath: string,
+  tempDir: string,
+  fullTrackOutput: string
+): Promise<{ stdout: string; stderr: string }> {
+  // TODO: Covnert it and mod formats
+  const { stdout, stderr } = await execAsync(
+    `"${config.tools.milkyCliPath}" "${modulePath}" -output "${join(
+      tempDir,
+      fullTrackOutput
+    )}"`
+  );
+  return { stdout, stderr };
+}
+
+async function convertComponents(
+  moduleFormat: SourceFormat,
+  modulePath: string,
+  tempDir: string,
+  componentsBaseName: string
+): Promise<{ stdout: string; stderr: string }> {
+  // TODO: Convert it and mod formats
+  const { stdout, stderr } = await execAsync(
+    `"${config.tools.milkyCliPath}" "${modulePath}" -output "${join(
+      tempDir,
+      componentsBaseName
+    )}" -multi-track`
+  );
+  return { stdout, stderr };
+}
+
+export async function convertModuleToWAV(
+  moduleBuffer: Buffer,
+  moduleFormat: SourceFormat
 ): Promise<ConversionResult> {
   try {
     // Create temporary directory
+
+    // Create temporary directory
     const tempDir = await mkdtemp(join(tmpdir(), "wavtopia-"));
-    const xmPath = join(tempDir, "input.xm");
+    const modulePath = join(tempDir, `input.${moduleFormat}`);
     const fullTrackOutput = "full_track.wav";
     const componentsBaseName = "output.wav"; // Base name for component files (will become output_01.wav, etc.)
 
     try {
-      // Write XM file to temp directory
-      await writeFile(xmPath, xmBuffer);
+      // Write module file to temp directory
+      await writeFile(modulePath, moduleBuffer);
 
       // First, convert the full track
-      const { stderr: fullTrackStderr } = await execAsync(
-        `"${config.tools.milkyCliPath}" "${xmPath}" -output "${join(
-          tempDir,
-          fullTrackOutput
-        )}"`
+      const { stderr: fullTrackStderr } = await convertFullTrack(
+        moduleFormat,
+        modulePath,
+        tempDir,
+        fullTrackOutput
       );
 
       if (fullTrackStderr) {
@@ -52,11 +88,11 @@ export async function convertXMToWAV(
       );
 
       // Then convert individual components
-      const { stderr: componentsStderr } = await execAsync(
-        `"${config.tools.milkyCliPath}" "${xmPath}" -output "${join(
-          tempDir,
-          componentsBaseName
-        )}" -multi-track`
+      const { stderr: componentsStderr } = await convertComponents(
+        moduleFormat,
+        modulePath,
+        tempDir,
+        componentsBaseName
       );
 
       if (componentsStderr) {
@@ -95,8 +131,8 @@ export async function convertXMToWAV(
       await rm(tempDir, { recursive: true, force: true });
     }
   } catch (error) {
-    console.error("Error converting XM to WAV:", error);
-    throw new AppError(500, "Failed to convert XM to WAV components");
+    console.error("Error converting module to WAV:", error);
+    throw new AppError(500, "Failed to convert module to WAV components");
   }
 }
 

--- a/packages/media/src/services/queue/track-conversion-queue.ts
+++ b/packages/media/src/services/queue/track-conversion-queue.ts
@@ -1,5 +1,5 @@
 import { Job } from "bull";
-import { convertXMToWAV } from "../module-converter";
+import { convertModuleToWAV } from "../module-converter";
 import { convertWAVToMP3 } from "../../services/mp3-converter";
 import { generateWaveformData } from "../../services/waveform";
 import { StorageFile } from "@wavtopia/core-storage";
@@ -182,12 +182,13 @@ trackConversionQueue.process(async (job: Job<TrackConversionJob>) => {
       console.log("Cover art uploaded:", coverArtUrl);
     }
 
-    // Convert XM to WAV
-    console.log("Converting XM to WAV...");
-    const { fullTrackWavBuffer, components } = await convertXMToWAV(
-      originalFile.buffer
+    // Convert module to WAV
+    console.log("Converting module to WAV...");
+    const { fullTrackWavBuffer, components } = await convertModuleToWAV(
+      originalFile.buffer,
+      track.originalFormat
     );
-    console.log("XM conversion complete. Components:", components.length);
+    console.log("Module conversion complete. Components:", components.length);
 
     const {
       mp3Url: fullTrackMp3Url,

--- a/packages/media/src/services/storage.ts
+++ b/packages/media/src/services/storage.ts
@@ -58,6 +58,10 @@ function getMimeType(filename: string): string {
       return "audio/wav";
     case "xm":
       return "audio/x-xm";
+    case "it":
+      return "audio/x-it";
+    case "mod":
+      return "audio/x-mod";
     case "flac":
       return "audio/flac";
     case "jpg":

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -48,12 +48,9 @@ while [[ "$#" -gt 0 ]]; do
             ;;
         -d|--debug) 
             DEBUG=true
-            shift
             ;;
         build-workspace|build-media|build-backend|build-services|up-dev|up-prod|down|down-volumes|clean|setup-remote|deploy-prod|test-registry|bootstrap-prod)
             COMMAND="$1"
-            shift
-            break
             ;;
         *)
             echo "Unknown parameter: $1"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,6 +4,7 @@ set -e
 # Default values
 REGISTRY_PORT="5000"
 COMMAND=""
+DEBUG=false
 
 # Help message
 show_help() {
@@ -27,13 +28,22 @@ Commands:
 
 Options:
   -h, --help       Show this help message
+  -d, --debug      Enable debug/verbose output
 EOT
+}
+
+# Debug logging function
+debug_log() {
+    if [ "$DEBUG" = true ]; then
+        echo "[DEBUG] $1"
+    fi
 }
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -h|--help) show_help; exit 0 ;;
+        -d|--debug) DEBUG=true; shift ;;
         build-*|up-*|down*|clean|setup-remote|deploy-prod|test-registry|bootstrap-prod) COMMAND="$1" ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
@@ -225,16 +235,32 @@ build_service() {
     local service_name="$1"
     local temp_file=$(mktemp)
     
+    debug_log "Building service: $service_name"
+    debug_log "Using temporary file: $temp_file"
+    
+    # Add --progress=plain when debug is enabled
+    local build_args=""
+    if [ "$DEBUG" = true ]; then
+        build_args="--progress=plain"
+        debug_log "Using build args: $build_args"
+    fi
+    
     # Build and capture the image ID
-    COMPOSE_DOCKER_CLI_BUILD=1 docker compose build "$service_name" 2>&1 | while read -r line; do
-        echo "$line"
+    debug_log "Starting build for $service_name..."
+    COMPOSE_DOCKER_CLI_BUILD=1 docker compose build $build_args "$service_name" 2>&1 | while read -r line; do
+        if [ "$DEBUG" = true ]; then
+            echo "[BUILD] $line"
+        else
+            echo "$line"
+        fi
         if [[ $line =~ "writing image sha256:" ]]; then
             echo "$line" | sed -n 's/.*sha256:\([a-f0-9]*\).*/sha256:\1/p' > "$temp_file"
-            echo "${service_name} image ID: $(cat "$temp_file")"
+            debug_log "${service_name} image ID: $(cat "$temp_file")"
         fi
     done
 
     new_docker_image_id=$(cat "$temp_file")
+    debug_log "Build complete. Image ID: $new_docker_image_id"
     rm "$temp_file"
 }
 
@@ -256,6 +282,8 @@ build_workspace() {
 # Function to deploy to production
 deploy_prod() {
     echo "Deploying to production server..."
+    debug_log "Starting deployment process"
+    
     if ! docker --context production info >/dev/null 2>&1; then
         echo "Cannot connect to production server. Please run setup-remote first."
         exit 1
@@ -265,32 +293,41 @@ deploy_prod() {
     REMOTE_HOST=$(docker context inspect production --format '{{.Endpoints.docker.Host}}' | sed 's|ssh://||' | cut -d':' -f1)
     REMOTE_USER=$(echo "$REMOTE_HOST" | cut -d'@' -f1)
     REMOTE_HOSTNAME=$(echo "$REMOTE_HOST" | cut -d'@' -f2)
+    debug_log "Remote host details: User=$REMOTE_USER, Hostname=$REMOTE_HOSTNAME"
     
     # Get actual registry port before setting up tunnel
     REGISTRY_PORT=$(get_registry_port)
-    echo "Detected registry port: ${REGISTRY_PORT}"
+    debug_log "Detected registry port: ${REGISTRY_PORT}"
     REGISTRY="localhost:${REGISTRY_PORT}"
 
     # Set up SSH tunnel
+    debug_log "Setting up SSH tunnel to $REMOTE_HOST"
     setup_tunnel "$REMOTE_HOST"
 
     # Build and tag images locally
     echo "Building images locally..."
     docker context use default
+    debug_log "Switched to default context"
     
     # Build workspace first since other images depend on it
+    debug_log "Starting workspace build"
     build_workspace
 
     # Build and push services
+    debug_log "Starting media service build"
     build_media
 
     local media_image_id="$new_docker_image_id"
+    debug_log "Media image built with ID: $media_image_id"
 
+    debug_log "Starting backend service build"
     build_backend
 
     local backend_image_id="$new_docker_image_id"
+    debug_log "Backend image built with ID: $backend_image_id"
 
     # Tag and push using image IDs to ensure we use the correct images
+    debug_log "Tagging and pushing images to registry at $REGISTRY"
     docker tag "${media_image_id}" "${REGISTRY}/wavtopia-media:latest"
     docker tag "${backend_image_id}" "${REGISTRY}/wavtopia-backend:latest"
     docker push "${REGISTRY}/wavtopia-media:latest"
@@ -299,10 +336,11 @@ deploy_prod() {
     # Switch to production context and deploy
     echo "Deploying services..."
     docker context use production
+    debug_log "Switched to production context"
     
     # Use localhost for registry when deploying since we're on the remote host
     export REGISTRY_PREFIX="localhost:${REGISTRY_PORT}/"
-    echo "Using registry at ${REGISTRY_PREFIX}"
+    debug_log "Using registry prefix: ${REGISTRY_PREFIX}"
     
     # Pull latest images
     echo "Pulling latest images..."
@@ -310,6 +348,7 @@ deploy_prod() {
     docker pull "${REGISTRY_PREFIX}wavtopia-backend:latest"
     
     # Deploy services first to ensure database is running
+    debug_log "Starting production services"
     docker compose --profile production pull
     docker compose --profile production up -d
     
@@ -319,11 +358,13 @@ deploy_prod() {
     
     # Run database migrations in production
     echo "Running database migrations..."
+    debug_log "Executing database migrations"
     docker compose --profile production run --rm \
       backend sh -c "cd /app/node_modules/@wavtopia/core-storage && npm run migrate:deploy"
     
     # Switch back to default context
     docker context use default
+    debug_log "Switched back to default context"
     echo "Services deployed! Don't forget to update the frontend too if there are any changes."
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -42,13 +42,33 @@ debug_log() {
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
-        -h|--help) show_help; exit 0 ;;
-        -d|--debug) DEBUG=true; shift ;;
-        build-*|up-*|down*|clean|setup-remote|deploy-prod|test-registry|bootstrap-prod) COMMAND="$1" ;;
-        *) echo "Unknown parameter: $1"; exit 1 ;;
+        -h|--help) 
+            show_help
+            exit 0 
+            ;;
+        -d|--debug) 
+            DEBUG=true
+            shift
+            ;;
+        build-workspace|build-media|build-backend|build-services|up-dev|up-prod|down|down-volumes|clean|setup-remote|deploy-prod|test-registry|bootstrap-prod)
+            COMMAND="$1"
+            shift
+            break
+            ;;
+        *)
+            echo "Unknown parameter: $1"
+            exit 1
+            ;;
     esac
     shift
 done
+
+# Check if a command was specified
+if [ -z "$COMMAND" ]; then
+    echo "No command specified"
+    show_help
+    exit 1
+fi
 
 # Function to cleanup SSH tunnel
 cleanup_tunnel() {


### PR DESCRIPTION
This PR extends Wavtopia's audio format support to include Impulse Tracker (.it) and ProTracker/FastTracker (.mod) files alongside the existing FastTracker 2 (.xm) support.

Key changes:
- Added Schism Tracker integration for IT/MOD file conversion
- Updated database schema with new SourceFormat enum
- Modified frontend upload components to accept new formats
- Split build process into separate tools and runtime images
- Updated documentation and error messages for new format support