### PR TITLE
Optimize docker builds with shared apt-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
-FROM node:18-slim AS apt-base
-
-# Run apt-get update once for all downstream images
-RUN apt-get update
-
-FROM apt-base AS base
+ARG WORKSPACE_APT_IMAGE
+FROM ${WORKSPACE_APT_IMAGE}
 
 SHELL ["/bin/sh", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM node:18-slim AS base
+FROM node:18-slim AS apt-base
+
+# Run apt-get update once for all downstream images
+RUN apt-get update
+
+FROM apt-base AS base
 
 SHELL ["/bin/sh", "-c"]
 
 # Install system dependencies - just openssl for now, to ensure it's aligned with the media service
 # where openssl is installed as a by-product of the build process. The prisma client needs it.
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get install -y --no-install-recommends \
     openssl \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.apt-base
+++ b/Dockerfile.apt-base
@@ -1,0 +1,4 @@
+FROM node:18-slim
+
+# Run apt-get update once for all downstream images
+RUN apt-get update 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     build:
       context: packages/media
       dockerfile: Dockerfile.tools
+      args:
+        - WORKSPACE_IMAGE=${REGISTRY_PREFIX:-}wavtopia-workspace
     image: ${REGISTRY_PREFIX:-}wavtopia-tools
 
   workspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,21 @@ services:
     build:
       context: packages/media
       dockerfile: Dockerfile.tools
+      args:
+        - WORKSPACE_APT_IMAGE=${REGISTRY_PREFIX:-}wavtopia-apt-base
     image: ${REGISTRY_PREFIX:-}wavtopia-tools
+    depends_on:
+      workspace-apt-base:
+        condition: service_completed_successfully
+
+  workspace-apt-base:
+    profiles:
+      - build
+      - production
+    build:
+      context: .
+      dockerfile: Dockerfile.apt-base
+    image: ${REGISTRY_PREFIX:-}wavtopia-apt-base
 
   workspace:
     profiles:
@@ -60,7 +74,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - WORKSPACE_APT_IMAGE=${REGISTRY_PREFIX:-}wavtopia-apt-base
     image: ${REGISTRY_PREFIX:-}wavtopia-workspace
+    depends_on:
+      workspace-apt-base:
+        condition: service_completed_successfully
 
   media:
     profiles:
@@ -70,6 +89,7 @@ services:
       dockerfile: Dockerfile
       args:
         - WORKSPACE_IMAGE=${REGISTRY_PREFIX:-}wavtopia-workspace
+        - WORKSPACE_APT_IMAGE=${REGISTRY_PREFIX:-}wavtopia-apt-base
     image: ${REGISTRY_PREFIX:-}wavtopia-media
     ports:
       - "3001:3001"
@@ -94,6 +114,7 @@ services:
       dockerfile: packages/backend/Dockerfile
       args:
         - WORKSPACE_IMAGE=${REGISTRY_PREFIX:-}wavtopia-workspace
+        - WORKSPACE_APT_IMAGE=${REGISTRY_PREFIX:-}wavtopia-apt-base
     image: ${REGISTRY_PREFIX:-}wavtopia-backend
     ports:
       - "3002:3002"
@@ -103,8 +124,6 @@ services:
     networks:
       - wavtopia-net
     depends_on:
-      workspace:
-        condition: service_completed_successfully
       minio:
         condition: service_started
       redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,6 @@ services:
   workspace-apt-base:
     profiles:
       - build
-      - production
     build:
       context: .
       dockerfile: Dockerfile.apt-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,6 @@ services:
   workspace:
     profiles:
       - build
-      - production
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,6 @@ services:
     build:
       context: packages/media
       dockerfile: Dockerfile.tools
-      args:
-        - WORKSPACE_IMAGE=${REGISTRY_PREFIX:-}wavtopia-workspace
     image: ${REGISTRY_PREFIX:-}wavtopia-tools
 
   workspace:

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,12 +1,15 @@
-# Get the workspace image name from build args
+# Get the workspace image names from build args
 ARG WORKSPACE_IMAGE
+ARG WORKSPACE_APT_IMAGE
+
+# Use workspace image for building
 FROM ${WORKSPACE_IMAGE} AS prod-build
 
 # Create prod-build deployment for backend service
 RUN pnpm --filter @wavtopia/backend --prod deploy backend-service
 
 # Create the final image
-FROM ${WORKSPACE_IMAGE} AS apt-base
+FROM ${WORKSPACE_APT_IMAGE}
 
 # Install system dependencies - just openssl for now, to ensure it's aligned with the media service
 # where openssl is installed as a by-product of the build process. The prisma client needs it.

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -6,12 +6,11 @@ FROM ${WORKSPACE_IMAGE} AS prod-build
 RUN pnpm --filter @wavtopia/backend --prod deploy backend-service
 
 # Create the final image
-FROM node:18-slim
+FROM apt-base
 
 # Install system dependencies - just openssl for now, to ensure it's aligned with the media service
 # where openssl is installed as a by-product of the build process. The prisma client needs it.
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get install -y --no-install-recommends \
     openssl \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -6,7 +6,7 @@ FROM ${WORKSPACE_IMAGE} AS prod-build
 RUN pnpm --filter @wavtopia/backend --prod deploy backend-service
 
 # Create the final image
-FROM apt-base
+FROM ${WORKSPACE_IMAGE} AS apt-base
 
 # Install system dependencies - just openssl for now, to ensure it's aligned with the media service
 # where openssl is installed as a by-product of the build process. The prisma client needs it.

--- a/packages/media/Dockerfile
+++ b/packages/media/Dockerfile
@@ -11,7 +11,7 @@ FROM ${WORKSPACE_IMAGE} AS prod-build
 RUN pnpm --filter @wavtopia/media --prod deploy media-service
 
 # Create the final image
-FROM apt-base
+FROM ${WORKSPACE_IMAGE} AS apt-base
 
 # Install runtime dependencies only
 RUN apt-get install -y --no-install-recommends \

--- a/packages/media/Dockerfile
+++ b/packages/media/Dockerfile
@@ -1,17 +1,18 @@
-# Get the workspace image name from build args
+# Get the workspace image names from build args
 ARG WORKSPACE_IMAGE
+ARG WORKSPACE_APT_IMAGE
 
 # Build the tools image first
 FROM wavtopia-tools AS tools
 
-# Use workspace image for building the service
+# Use workspace image for building
 FROM ${WORKSPACE_IMAGE} AS prod-build
 
 # Create deployment for media service
 RUN pnpm --filter @wavtopia/media --prod deploy media-service
 
 # Create the final image
-FROM ${WORKSPACE_IMAGE} AS apt-base
+FROM ${WORKSPACE_APT_IMAGE}
 
 # Install runtime dependencies only
 RUN apt-get install -y --no-install-recommends \

--- a/packages/media/Dockerfile
+++ b/packages/media/Dockerfile
@@ -11,11 +11,10 @@ FROM ${WORKSPACE_IMAGE} AS prod-build
 RUN pnpm --filter @wavtopia/media --prod deploy media-service
 
 # Create the final image
-FROM node:18-slim
+FROM apt-base
 
 # Install runtime dependencies only
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
     ffmpeg \
     lame \
     # Schism Tracker dependencies

--- a/packages/media/Dockerfile.tools
+++ b/packages/media/Dockerfile.tools
@@ -1,5 +1,6 @@
-ARG WORKSPACE_IMAGE
-FROM ${WORKSPACE_IMAGE} AS apt-base
+# Get the workspace image name from build args
+ARG WORKSPACE_APT_IMAGE
+FROM ${WORKSPACE_APT_IMAGE}
 
 # Install build dependencies
 RUN apt-get install -y --no-install-recommends \

--- a/packages/media/Dockerfile.tools
+++ b/packages/media/Dockerfile.tools
@@ -1,4 +1,5 @@
-FROM apt-base
+ARG WORKSPACE_IMAGE
+FROM ${WORKSPACE_IMAGE} AS apt-base
 
 # Install build dependencies
 RUN apt-get install -y --no-install-recommends \

--- a/packages/media/Dockerfile.tools
+++ b/packages/media/Dockerfile.tools
@@ -1,8 +1,7 @@
-FROM node:18-slim
+FROM apt-base
 
 # Install build dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
     # MilkyTracker dependencies
     build-essential \
     cmake \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -311,7 +311,7 @@ build_tools() {
 # Function to build workspace (used by other build commands)
 build_workspace() {
     debug_log "Building workspace..."
-    docker compose --profile build build workspace
+    docker compose --profile build build workspace-apt-base workspace
 }
 
 # Function to build media service (used by other build commands)


### PR DESCRIPTION
This PR optimizes Docker builds by introducing a shared base image for apt package management. Key changes:

- Add new `Dockerfile.apt-base` that runs `apt-get update` once for all downstream images
- Update service Dockerfiles to use the shared apt-base image via build args
- Remove redundant `apt-get update` calls across services
- Add proper build dependencies in docker-compose.yml to ensure correct build order
- Update deploy script to build apt-base image before workspace

This change reduces build time and image size by:
- Eliminating duplicate apt-get update operations
- Sharing the same apt package lists across images
- Ensuring consistent package versions across services