### PR TITLE
Add file cleanup indexes and improve cleanup process

### DIFF
--- a/packages/core-storage/prisma/migrations/20250219011540_add_file_cleanup_indexes/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250219011540_add_file_cleanup_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- CreateIndex
+CREATE INDEX "components_wav_last_requested_at_idx" ON "components"("wav_last_requested_at");
+
+-- CreateIndex
+CREATE INDEX "components_flac_last_requested_at_idx" ON "components"("flac_last_requested_at");
+
+-- CreateIndex
+CREATE INDEX "tracks_original_format_wav_last_requested_at_idx" ON "tracks"("original_format", "wav_last_requested_at");
+
+-- CreateIndex
+CREATE INDEX "tracks_original_format_flac_last_requested_at_idx" ON "tracks"("original_format", "flac_last_requested_at");

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -70,6 +70,8 @@ model Track {
   @@index([title, id])
   @@index([artist, id])
   @@index([duration, id])
+  @@index([originalFormat, wavLastRequestedAt])
+  @@index([originalFormat, flacLastRequestedAt])
   @@map("tracks")
 }
 
@@ -108,6 +110,8 @@ model Component {
   updatedAt             DateTime                   @updatedAt @map("updated_at")
 
   @@unique([trackId, index])
+  @@index([wavLastRequestedAt])
+  @@index([flacLastRequestedAt])
   @@map("components")
 }
 

--- a/packages/media/src/services/audio-file-converter.ts
+++ b/packages/media/src/services/audio-file-converter.ts
@@ -34,8 +34,9 @@ async function convertWAVToFLAC(wavBuffer: Buffer): Promise<Buffer> {
       // Convert to FLAC using FFmpeg
       // -compression_level 5 provides a good balance between compression and speed
       // Range is 0-12, where 0 is fastest/largest, 12 is slowest/smallest
+      // Note, to see more output in the logs, remove the -loglevel error flag
       const { stderr } = await execAsync(
-        `ffmpeg -i "${wavPath}" -c:a flac -compression_level 5 "${flacPath}"`
+        `ffmpeg -loglevel error -i "${wavPath}" -c:a flac -compression_level 5 "${flacPath}"`
       );
 
       if (stderr) {
@@ -68,7 +69,7 @@ async function convertFLACToWAV(flacBuffer: Buffer): Promise<Buffer> {
 
       // Convert to WAV using FFmpeg
       const { stderr } = await execAsync(
-        `ffmpeg -i "${flacPath}" -c:a pcm_s16le "${wavPath}"`
+        `ffmpeg -loglevel error -i "${flacPath}" -c:a pcm_s16le "${wavPath}"`
       );
 
       if (stderr) {

--- a/packages/media/src/services/mp3-converter.ts
+++ b/packages/media/src/services/mp3-converter.ts
@@ -27,8 +27,9 @@ export async function convertWAVToMP3(
       // Piping through 'cat' maintains clean stream writing, preserving the exact timing of the audio data.
       // This is crucial for accurate seeking in the browser's audio player.
       // TODO: Find a better solution that doesn't require piping through 'cat'.
+      // Note, to see more output in the logs, remove the -loglevel error flag
       const { stderr } = await execAsync(
-        `ffmpeg -i "${wavPath}" -f wav - | lame -b ${kbps} --cbr --noreplaygain --pad-id3v2 - | cat > "${mp3Path}"`
+        `ffmpeg -loglevel error -i "${wavPath}" -f wav - | lame -b ${kbps} --cbr --noreplaygain --pad-id3v2 - | cat > "${mp3Path}"`
       );
 
       if (stderr) {

--- a/packages/media/src/services/queue/audio-file-conversion-queue.ts
+++ b/packages/media/src/services/queue/audio-file-conversion-queue.ts
@@ -207,15 +207,11 @@ async function audioFileConversionProcessor(job: Job<AudioFileConversionJob>) {
         format
       );
 
-      const componentIndex = track.components.findIndex(
-        (c) => c.id === componentId
-      );
-
       const audioBuffer = await convertToFormat(
         track,
         component[sourceUrlProperty],
         format,
-        componentIndex
+        component.index
       );
 
       // Upload WAV file

--- a/packages/media/src/services/queue/file-cleanup-queue.ts
+++ b/packages/media/src/services/queue/file-cleanup-queue.ts
@@ -83,33 +83,31 @@ async function fileCleanupProcessor(job: Job<FileCleanupJob>) {
           },
           {
             OR: [
-              // Track has old WAV/FLAC files
+              // Track WAV file conditions
               {
-                OR: [
-                  {
-                    fullTrackWavUrl: { not: null },
-                    wavLastRequestedAt: { lt: thresholdDate },
-                  },
-                  {
-                    fullTrackFlacUrl: { not: null },
-                    flacLastRequestedAt: { lt: thresholdDate },
-                  },
-                ],
+                fullTrackWavUrl: { not: null },
+                wavLastRequestedAt: { lt: thresholdDate },
               },
-              // Track has components with old WAV/FLAC files
+              // Track FLAC file conditions
+              {
+                fullTrackFlacUrl: { not: null },
+                flacLastRequestedAt: { lt: thresholdDate },
+              },
+              // Component WAV file conditions
               {
                 components: {
                   some: {
-                    OR: [
-                      {
-                        wavUrl: { not: null },
-                        wavLastRequestedAt: { lt: thresholdDate },
-                      },
-                      {
-                        flacUrl: { not: null },
-                        flacLastRequestedAt: { lt: thresholdDate },
-                      },
-                    ],
+                    wavUrl: { not: null },
+                    wavLastRequestedAt: { lt: thresholdDate },
+                  },
+                },
+              },
+              // Component FLAC file conditions
+              {
+                components: {
+                  some: {
+                    flacUrl: { not: null },
+                    flacLastRequestedAt: { lt: thresholdDate },
                   },
                 },
               },

--- a/packages/media/src/services/queue/file-cleanup-queue.ts
+++ b/packages/media/src/services/queue/file-cleanup-queue.ts
@@ -344,6 +344,10 @@ async function fileCleanupProcessor(job: Job<FileCleanupJob>) {
         job.data, // Reuse the exact same job data to maintain consistency
         {
           ...standardJobOptions,
+          // Note, this means the next job will run a minute after the previous one but with
+          // the same relative time threshold, so more tracks may fall within the threshold\
+          // on the next run. This should be OK in real-world usage with a threshold measured
+          // in days.
           delay: delayMinutes * 60000,
         }
       );


### PR DESCRIPTION
Changes:
- Add database indexes on wav/flac last requested timestamps for tracks and components to optimize file cleanup queries
- Implement batched processing (50 tracks per batch) with automatic follow-up jobs
- Add retry mechanism for file deletions with exponential backoff
- Improve error handling and reporting during cleanup process
- Reduce FFmpeg log verbosity by adding -loglevel error flag