### PR TITLE
Implement primary artist relationship and prepare schema for extended metadata

### DIFF
--- a/packages/backend/src/routes/tracks.ts
+++ b/packages/backend/src/routes/tracks.ts
@@ -26,7 +26,7 @@ function extractPaginationParams(req: Request) {
     | "createdAt"
     | "title"
     | "duration"
-    | "artist"
+    | "primaryArtistName"
     | undefined;
   const sortDirection = req.query.sortDirection as "asc" | "desc" | undefined;
 
@@ -38,7 +38,7 @@ async function getPaginatedTracks<I extends Prisma.TrackInclude>(
   where: Prisma.TrackWhereInput,
   include: I,
   params: PaginationParams & {
-    sortField?: "createdAt" | "title" | "duration" | "artist";
+    sortField?: "createdAt" | "title" | "duration" | "primaryArtistName";
     sortDirection?: "asc" | "desc";
   }
 ): Promise<PaginatedResponse<Prisma.TrackGetPayload<{ include: I }>>> {

--- a/packages/backend/src/utils/entityManagement.ts
+++ b/packages/backend/src/utils/entityManagement.ts
@@ -1,0 +1,39 @@
+import { prisma } from "../lib/prisma";
+
+/**
+ * Find or create an entity by name, ensuring consistent name handling
+ * @param entityType The type of entity (e.g., 'artist', 'genre', 'mood')
+ * @param name The name to find or create
+ * @returns The found or created entity
+ */
+export async function findOrCreateByName(
+  entityType: "artist" | "genre" | "mood" | "tag",
+  name: string
+) {
+  // Ensure name is trimmed
+  const trimmedName = name.trim();
+
+  // Type assertion to help TypeScript understand the dynamic access
+  const model = prisma[entityType] as unknown as {
+    findFirst: (args: {
+      where: { name: string };
+    }) => Promise<{ id: string; name: string } | null>;
+    create: (args: {
+      data: { name: string };
+    }) => Promise<{ id: string; name: string }>;
+  };
+
+  // Find existing entity
+  const existing = await model.findFirst({
+    where: { name: trimmedName },
+  });
+
+  if (existing) {
+    return existing;
+  }
+
+  // Create new entity if not found
+  return await model.create({
+    data: { name: trimmedName },
+  });
+}

--- a/packages/core-storage/prisma/README.md
+++ b/packages/core-storage/prisma/README.md
@@ -226,3 +226,76 @@ const searchResults = await prisma.$queryRaw`
    - Parallel-safe functions
    - Optimized change detection
    - Minimal redundant processing
+
+### Maintenance Functions
+
+The implementation includes several utility functions for maintaining search vectors. The initial setup is handled automatically during migration, but these functions are available for maintenance and troubleshooting:
+
+1. **Batch Update Function**:
+
+   ```sql
+   -- Update search vectors for all tracks
+   SELECT update_all_tracks_search_vector();
+   ```
+
+   - Updates both search vectors and hashes in a single batch operation
+   - Useful for rebuilding search vectors if needed
+   - Uses a single UPDATE statement to minimize database load
+   - Automatically run during migration for initial setup
+
+2. **Single Track Update**:
+
+   ```sql
+   -- Update search vector for a specific track
+   SELECT update_track_search_vector('track-uuid');
+   ```
+
+   - Updates search vector and hash for one track
+   - Useful for manual fixes or testing
+   - Same logic as the batch update for consistency
+
+3. **Integrity Verification**:
+   ```sql
+   -- Find tracks with mismatched search hashes
+   SELECT * FROM verify_tracks_search_vector();
+   ```
+   - Returns tracks where current hash doesn't match content
+   - Helps identify data integrity issues
+   - Shows track ID, title, and both hashes for comparison
+
+Common maintenance scenarios:
+
+1. **After Database Restore/Clone**:
+
+   ```sql
+   -- Verify search vector integrity
+   SELECT * FROM verify_tracks_search_vector();
+
+   -- Rebuild if needed
+   SELECT update_all_tracks_search_vector();
+   ```
+
+2. **Troubleshooting Search Issues**:
+
+   ```sql
+   -- Check specific track's search vector
+   SELECT id, title, search_vector, search_config_hash
+   FROM tracks
+   WHERE id = 'track-uuid';
+
+   -- Update if needed
+   SELECT update_track_search_vector('track-uuid');
+   ```
+
+3. **Regular Maintenance**:
+
+   ```sql
+   -- Find any tracks with mismatched hashes
+   SELECT * FROM verify_tracks_search_vector();
+
+   -- Fix specific tracks as needed
+   SELECT update_track_search_vector(id)
+   FROM verify_tracks_search_vector();
+   ```
+
+These functions provide tools for maintaining and troubleshooting the full-text search implementation over time. The initial setup is handled automatically by the migration, so manual initialization is only needed in special cases like database restores or integrity checks.

--- a/packages/core-storage/prisma/README.md
+++ b/packages/core-storage/prisma/README.md
@@ -1,0 +1,228 @@
+# Track Schema Extensions
+
+This directory contains files related to extending the Track model with additional metadata fields and relationships.
+
+## Files
+
+- `schema.prisma`: The main Prisma schema file
+- `track_extensions.prisma`: Contains normalized models related to Track (RecordLabel, Genre, Artist, etc.)
+- `track_model_extensions.prisma`: Shows how to extend the Track model with new fields and relationships
+- `full_text_search.sql`: SQL statements for implementing PostgreSQL full-text search
+
+## Implementation Guide
+
+### Step 1: Merge the Extensions into the Main Schema
+
+To implement these extensions, you need to:
+
+1. Copy the models from `track_extensions.prisma` into your main `schema.prisma` file
+2. Add the fields and relationships from `track_model_extensions.prisma` to your Track model in `schema.prisma`
+
+### Step 2: Create a Migration
+
+After updating your schema, create a migration:
+
+```bash
+npx prisma migrate dev --name add_track_extensions
+```
+
+### Step 3: Implement Full-Text Search
+
+The full-text search implementation uses PostgreSQL's built-in text search capabilities with several performance optimizations:
+
+1. **Search Vector**: A `tsvector` column stores pre-processed searchable text
+2. **Change Detection**: Uses MD5 hashing to efficiently detect changes in searchable content
+3. **Weighted Search**: Different fields have different search weights:
+   - Weight A: title, primaryArtistName (highest priority)
+   - Weight B: description, genres, moods, artistNames (medium priority)
+   - Weight C: lyrics, tags (lower priority)
+
+Key features of the implementation:
+
+- **Efficient Updates**: Only recalculates search vectors when searchable content changes
+- **Optimized Storage**: Uses hash-based change detection to minimize processing
+- **Parallel-Safe**: Functions are marked as PARALLEL SAFE for better performance
+- **GIN Indexing**: Uses GIN indexes for fast full-text search queries
+
+### Search and Filtering Considerations
+
+Two main approaches are implemented for efficient searching and filtering:
+
+1. **PostgreSQL Full-Text Search**:
+
+   - Uses `tsvector` column with GIN index
+   - Efficient change detection using MD5 hashing
+   - Weighted search results based on field importance
+   - Parallel-safe functions for better performance
+
+2. **Denormalized Arrays for Filtering**:
+   - Array columns with GIN indexes
+   - Efficient filtering without joins
+   - Works well with Prisma's query API
+
+Performance optimizations include:
+
+- Hash-based change detection to avoid unnecessary updates
+- Efficient string concatenation using `concat_ws`
+- Immutable and parallel-safe functions
+- Batch processing for bulk updates
+- Strategic use of GIN indexes
+
+## Data Model Design Decisions
+
+### Normalized vs. Denormalized Approach
+
+The schema uses a hybrid approach:
+
+- **Normalized entities**: RecordLabel, Genre, Artist, Album, etc. are stored in separate tables
+- **Denormalized fields**: Frequently accessed metadata like bpm, key, releaseDate are stored directly in the Track table
+- **Denormalized arrays**: For efficient filtering, we store arrays of names (genreNames, moodNames, artistNames, tagNames) directly in the Track table
+- **Flexible storage**: Less structured or variable metadata can be stored in the `extendedMetadata` JSON field
+
+### Search and Filtering Considerations
+
+Two main approaches are implemented for efficient searching and filtering:
+
+1. **PostgreSQL Full-Text Search**: Implemented via the `search_vector` column and related triggers
+
+   - Pros: Integrated with the database, no additional infrastructure
+   - Cons: Limited scalability compared to dedicated search solutions
+
+2. **Denormalized Arrays for Filtering**: Implemented via array columns and triggers
+   - Pros: Efficient filtering without expensive joins, works well with Prisma's query API
+   - Cons: Requires keeping denormalized data in sync with triggers
+
+The implementation includes:
+
+- SQL triggers to maintain the denormalized arrays
+- GIN indexes for efficient array operations
+- Example TypeScript code for filtering using these arrays
+
+## Usage Examples
+
+### Querying Tracks with Related Data
+
+```typescript
+// Get a track with its genres and record label
+const track = await prisma.track.findUnique({
+  where: { id: trackId },
+  include: {
+    recordLabel: true,
+    genres: {
+      include: {
+        genre: true,
+      },
+    },
+  },
+});
+
+// Get all tracks by a specific artist (as composer)
+const tracks = await prisma.track.findMany({
+  where: {
+    credits: {
+      some: {
+        artist: {
+          name: "Artist Name",
+        },
+        creditType: "COMPOSER",
+      },
+    },
+  },
+});
+```
+
+### Filtering with Denormalized Arrays
+
+```typescript
+// Filter tracks by genre and BPM range (efficient, no joins needed)
+const tracks = await prisma.track.findMany({
+  where: {
+    genreNames: { hasSome: ["House", "Techno"] },
+    bpm: { gte: 120, lte: 130 },
+  },
+  orderBy: { createdAt: "desc" },
+  take: 20,
+});
+
+// Filter tracks by multiple criteria using denormalized arrays
+const tracks = await prisma.track.findMany({
+  where: {
+    genreNames: { hasSome: ["House"] },
+    moodNames: { hasSome: ["Energetic"] },
+    artistNames: { hasSome: ["DJ Name"] },
+    isExplicit: false,
+  },
+  orderBy: { createdAt: "desc" },
+  take: 20,
+});
+```
+
+### Using Full-Text Search
+
+```typescript
+// Basic full-text search with ranking
+const searchResults = await prisma.$queryRaw`
+  SELECT 
+    id, 
+    title, 
+    primary_artist_name,
+    ts_rank(search_vector, websearch_to_tsquery('english', ${searchTerm})) as rank
+  FROM tracks
+  WHERE search_vector @@ websearch_to_tsquery('english', ${searchTerm})
+  ORDER BY rank DESC
+  LIMIT 10
+`;
+
+// Advanced search combining full-text search with filters
+const searchResults = await prisma.$queryRaw`
+  SELECT 
+    id, 
+    title, 
+    primary_artist_name,
+    ts_rank(search_vector, websearch_to_tsquery('english', ${searchTerm})) as rank
+  FROM tracks
+  WHERE 
+    search_vector @@ websearch_to_tsquery('english', ${searchTerm})
+    AND genre_names && ${genres}::text[]
+    AND mood_names && ${moods}::text[]
+    AND bpm BETWEEN ${minBpm} AND ${maxBpm}
+  ORDER BY 
+    rank DESC,
+    created_at DESC
+  LIMIT ${limit}
+  OFFSET ${offset}
+`;
+
+// Example with plainto_tsquery for exact phrase matching
+const searchResults = await prisma.$queryRaw`
+  SELECT 
+    id, 
+    title, 
+    primary_artist_name,
+    ts_rank(search_vector, plainto_tsquery('english', ${exactPhrase})) as rank
+  FROM tracks
+  WHERE search_vector @@ plainto_tsquery('english', ${exactPhrase})
+  ORDER BY rank DESC
+  LIMIT 10
+`;
+```
+
+### Performance Considerations
+
+1. **Search Vector Updates**:
+
+   - Updates only occur when searchable content changes
+   - Change detection uses fast MD5 hashing
+   - Batch updates available for bulk processing
+
+2. **Query Optimization**:
+
+   - GIN indexes for both full-text search and array operations
+   - Weighted search results for better relevance
+   - Efficient combination of full-text search with other filters
+
+3. **Memory and CPU Usage**:
+   - Efficient string concatenation
+   - Parallel-safe functions
+   - Optimized change detection
+   - Minimal redundant processing

--- a/packages/core-storage/prisma/migrations/20250304001000_add_track_extensions/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304001000_add_track_extensions/migration.sql
@@ -1,0 +1,234 @@
+-- CreateEnum
+CREATE TYPE "CreditType" AS ENUM ('COMPOSER', 'PRODUCER', 'FEATURED_ARTIST', 'PERFORMER', 'MIX_ENGINEER', 'MASTERING_ENGINEER', 'LYRICIST', 'ARRANGER');
+
+-- AlterTable
+ALTER TABLE "tracks" ADD COLUMN     "bpm" DOUBLE PRECISION,
+ADD COLUMN     "c_line" TEXT,
+ADD COLUMN     "catalog_number" TEXT,
+ADD COLUMN     "copyright" TEXT,
+ADD COLUMN     "description" TEXT,
+ADD COLUMN     "encoding_technology" TEXT,
+ADD COLUMN     "is_explicit" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "isrc" TEXT,
+ADD COLUMN     "key" TEXT,
+ADD COLUMN     "language" TEXT,
+ADD COLUMN     "license_id" TEXT,
+ADD COLUMN     "lyrics" TEXT,
+ADD COLUMN     "original_release_date" TIMESTAMP(3),
+ADD COLUMN     "p_line" TEXT,
+ADD COLUMN     "peak_amplitude" DOUBLE PRECISION,
+ADD COLUMN     "record_label_id" TEXT,
+ADD COLUMN     "recording_location" TEXT,
+ADD COLUMN     "release_date" TIMESTAMP(3),
+ADD COLUMN     "remixed_by" TEXT,
+ADD COLUMN     "replay_gain" DOUBLE PRECISION,
+ADD COLUMN     "version" TEXT;
+
+-- CreateTable
+CREATE TABLE "record_labels" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "website" TEXT,
+    "logo_url" TEXT,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "record_labels_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "genres" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "genres_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "track_genres" (
+    "id" TEXT NOT NULL,
+    "track_id" TEXT NOT NULL,
+    "genre_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "track_genres_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "albums" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "release_date" TIMESTAMP(3),
+    "cover_art_url" TEXT,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "albums_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "track_albums" (
+    "id" TEXT NOT NULL,
+    "track_id" TEXT NOT NULL,
+    "album_id" TEXT NOT NULL,
+    "track_number" INTEGER,
+    "disc_number" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "track_albums_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "artists" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "bio" TEXT,
+    "image_url" TEXT,
+    "website" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "artists_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "track_credits" (
+    "id" TEXT NOT NULL,
+    "track_id" TEXT NOT NULL,
+    "artist_id" TEXT NOT NULL,
+    "credit_type" "CreditType" NOT NULL,
+    "role" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "track_credits_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "moods" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "moods_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "track_moods" (
+    "id" TEXT NOT NULL,
+    "track_id" TEXT NOT NULL,
+    "mood_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "track_moods_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "tags" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tags_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "track_tags" (
+    "id" TEXT NOT NULL,
+    "track_id" TEXT NOT NULL,
+    "tag_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "track_tags_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "licenses" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "terms" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "licenses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "record_labels_name_key" ON "record_labels"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "genres_name_key" ON "genres"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "track_genres_track_id_genre_id_key" ON "track_genres"("track_id", "genre_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "track_albums_track_id_album_id_key" ON "track_albums"("track_id", "album_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "track_credits_track_id_artist_id_credit_type_key" ON "track_credits"("track_id", "artist_id", "credit_type");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "moods_name_key" ON "moods"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "track_moods_track_id_mood_id_key" ON "track_moods"("track_id", "mood_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "tags_name_key" ON "tags"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "track_tags_track_id_tag_id_key" ON "track_tags"("track_id", "tag_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "licenses_name_key" ON "licenses"("name");
+
+-- AddForeignKey
+ALTER TABLE "tracks" ADD CONSTRAINT "tracks_record_label_id_fkey" FOREIGN KEY ("record_label_id") REFERENCES "record_labels"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "tracks" ADD CONSTRAINT "tracks_license_id_fkey" FOREIGN KEY ("license_id") REFERENCES "licenses"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_genres" ADD CONSTRAINT "track_genres_track_id_fkey" FOREIGN KEY ("track_id") REFERENCES "tracks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_genres" ADD CONSTRAINT "track_genres_genre_id_fkey" FOREIGN KEY ("genre_id") REFERENCES "genres"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_albums" ADD CONSTRAINT "track_albums_track_id_fkey" FOREIGN KEY ("track_id") REFERENCES "tracks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_albums" ADD CONSTRAINT "track_albums_album_id_fkey" FOREIGN KEY ("album_id") REFERENCES "albums"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_credits" ADD CONSTRAINT "track_credits_track_id_fkey" FOREIGN KEY ("track_id") REFERENCES "tracks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_credits" ADD CONSTRAINT "track_credits_artist_id_fkey" FOREIGN KEY ("artist_id") REFERENCES "artists"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_moods" ADD CONSTRAINT "track_moods_track_id_fkey" FOREIGN KEY ("track_id") REFERENCES "tracks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_moods" ADD CONSTRAINT "track_moods_mood_id_fkey" FOREIGN KEY ("mood_id") REFERENCES "moods"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_tags" ADD CONSTRAINT "track_tags_track_id_fkey" FOREIGN KEY ("track_id") REFERENCES "tracks"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "track_tags" ADD CONSTRAINT "track_tags_tag_id_fkey" FOREIGN KEY ("tag_id") REFERENCES "tags"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/core-storage/prisma/migrations/20250304001943_add_date_precision/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304001943_add_date_precision/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "DatePrecision" AS ENUM ('YEAR', 'MONTH', 'DAY');
+
+-- AlterTable
+ALTER TABLE "tracks" ADD COLUMN     "original_release_date_precision" "DatePrecision" DEFAULT 'DAY',
+ADD COLUMN     "release_date_precision" "DatePrecision" DEFAULT 'DAY';

--- a/packages/core-storage/prisma/migrations/20250304005240_add_primary_artist_id/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304005240_add_primary_artist_id/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "tracks" ADD COLUMN "primary_artist_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX "tracks_status_user_id_primary_artist_id_created_at_id_idx" ON "tracks"("status", "user_id", "primary_artist_id", "created_at", "id");
+
+-- AddForeignKey
+ALTER TABLE "tracks" ADD CONSTRAINT "tracks_primary_artist_id_fkey" FOREIGN KEY ("primary_artist_id") REFERENCES "artists"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/core-storage/prisma/migrations/20250304005244_add_denormalized_arrays/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304005244_add_denormalized_arrays/migration.sql
@@ -1,0 +1,249 @@
+-- This file SQL statements to implement denormalized arrays for many-to-many relationships
+
+-- 1. Add array columns to the tracks table
+ALTER TABLE "tracks" ADD COLUMN     "artist_names" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "genre_names" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "mood_names" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "tag_names" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- 2. Create GIN indexes on the array columns for efficient filtering
+CREATE INDEX idx_tracks_genre_names ON tracks USING GIN (genre_names);
+CREATE INDEX idx_tracks_mood_names ON tracks USING GIN (mood_names);
+CREATE INDEX idx_tracks_artist_names ON tracks USING GIN (artist_names);
+CREATE INDEX idx_tracks_tag_names ON tracks USING GIN (tag_names);
+
+-- 3. Create functions and triggers to keep the arrays in sync with the related tables
+
+-- Genre Names
+CREATE OR REPLACE FUNCTION update_track_genre_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET genre_names = array_append(genre_names, (SELECT name FROM genres WHERE id = NEW.genre_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET genre_names = array_remove(genre_names, (SELECT name FROM genres WHERE id = OLD.genre_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_genre_names_update
+AFTER INSERT OR DELETE ON track_genres
+FOR EACH ROW
+EXECUTE FUNCTION update_track_genre_names();
+
+-- Mood Names
+CREATE OR REPLACE FUNCTION update_track_mood_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET mood_names = array_append(mood_names, (SELECT name FROM moods WHERE id = NEW.mood_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET mood_names = array_remove(mood_names, (SELECT name FROM moods WHERE id = OLD.mood_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_mood_names_update
+AFTER INSERT OR DELETE ON track_moods
+FOR EACH ROW
+EXECUTE FUNCTION update_track_mood_names();
+
+-- Artist Names (from TrackCredit)
+CREATE OR REPLACE FUNCTION update_track_artist_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET artist_names = array_append(artist_names, (SELECT name FROM artists WHERE id = NEW.artist_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET artist_names = array_remove(artist_names, (SELECT name FROM artists WHERE id = OLD.artist_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_artist_names_update
+AFTER INSERT OR DELETE ON track_credits
+FOR EACH ROW
+EXECUTE FUNCTION update_track_artist_names();
+
+-- Tag Names
+CREATE OR REPLACE FUNCTION update_track_tag_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET tag_names = array_append(tag_names, (SELECT name FROM tags WHERE id = NEW.tag_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET tag_names = array_remove(tag_names, (SELECT name FROM tags WHERE id = OLD.tag_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_tag_names_update
+AFTER INSERT OR DELETE ON track_tags
+FOR EACH ROW
+EXECUTE FUNCTION update_track_tag_names();
+
+-- 4. Handle updates to the name fields in the related tables
+
+-- Genre Name Updates
+CREATE OR REPLACE FUNCTION update_genre_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET genre_names = array_replace(genre_names, OLD.name, NEW.name)
+    WHERE genre_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER genre_name_update
+AFTER UPDATE ON genres
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_genre_name_in_tracks();
+
+-- Mood Name Updates
+CREATE OR REPLACE FUNCTION update_mood_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET mood_names = array_replace(mood_names, OLD.name, NEW.name)
+    WHERE mood_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER mood_name_update
+AFTER UPDATE ON moods
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_mood_name_in_tracks();
+
+-- Artist Name Updates
+CREATE OR REPLACE FUNCTION update_artist_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET artist_names = array_replace(artist_names, OLD.name, NEW.name)
+    WHERE artist_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER artist_name_update
+AFTER UPDATE ON artists
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_artist_name_in_tracks();
+
+-- Tag Name Updates
+CREATE OR REPLACE FUNCTION update_tag_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET tag_names = array_replace(tag_names, OLD.name, NEW.name)
+    WHERE tag_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tag_name_update
+AFTER UPDATE ON tags
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_tag_name_in_tracks();
+
+-- 5. Function to populate the arrays for existing data
+CREATE OR REPLACE FUNCTION populate_track_array_fields() RETURNS void AS $$
+BEGIN
+  -- Populate genre_names
+  UPDATE tracks t
+  SET genre_names = ARRAY(
+    SELECT g.name
+    FROM genres g
+    JOIN track_genres tg ON g.id = tg.genre_id
+    WHERE tg.track_id = t.id
+  );
+  
+  -- Populate mood_names
+  UPDATE tracks t
+  SET mood_names = ARRAY(
+    SELECT m.name
+    FROM moods m
+    JOIN track_moods tm ON m.id = tm.mood_id
+    WHERE tm.track_id = t.id
+  );
+  
+  -- Populate artist_names
+  UPDATE tracks t
+  SET artist_names = ARRAY(
+    SELECT a.name
+    FROM artists a
+    JOIN track_credits tc ON a.id = tc.artist_id
+    WHERE tc.track_id = t.id
+  );
+  
+  -- Populate tag_names
+  UPDATE tracks t
+  SET tag_names = ARRAY(
+    SELECT tg.name
+    FROM tags tg
+    JOIN track_tags tt ON tg.id = tt.tag_id
+    WHERE tt.track_id = t.id
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Execute with: SELECT populate_track_array_fields();
+
+-- 6. Example queries for filtering using the denormalized arrays
+
+/*
+-- Find tracks with specific genres
+SELECT * FROM tracks
+WHERE genre_names && ARRAY['House', 'Techno']
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Find tracks with specific moods and BPM range
+SELECT * FROM tracks
+WHERE mood_names && ARRAY['Energetic', 'Happy']
+AND bpm BETWEEN 120 AND 130
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Find tracks with specific artists and tags
+SELECT * FROM tracks
+WHERE artist_names && ARRAY['Artist Name']
+AND tag_names && ARRAY['Summer', 'Dance']
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Combine with full-text search
+SELECT *, ts_rank(search_vector, to_tsquery('english', 'dance')) AS rank
+FROM tracks
+WHERE search_vector @@ to_tsquery('english', 'dance')
+AND genre_names && ARRAY['House']
+AND bpm > 120
+ORDER BY rank DESC
+LIMIT 20;
+*/ 

--- a/packages/core-storage/prisma/migrations/20250304005245_add_primary_artist_name/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304005245_add_primary_artist_name/migration.sql
@@ -1,0 +1,107 @@
+-- Add primary_artist_name column to tracks table
+ALTER TABLE "tracks" ADD COLUMN "primary_artist_name" TEXT;
+
+-- Create index for efficient filtering and sorting by primary artist name
+CREATE INDEX idx_tracks_primary_artist_name ON tracks (primary_artist_name);
+
+-- Create function to update primary_artist_name when primary_artist_id changes
+CREATE OR REPLACE FUNCTION update_primary_artist_name() RETURNS TRIGGER AS $$
+BEGIN
+  -- If primary_artist_id is set, get the artist name
+  IF NEW.primary_artist_id IS NOT NULL THEN
+    NEW.primary_artist_name := (SELECT name FROM artists WHERE id = NEW.primary_artist_id);
+    
+    -- Ensure the primary artist name is in the artistNames array
+    IF NEW.primary_artist_name IS NOT NULL AND 
+       (NEW.artist_names IS NULL OR NOT (NEW.artist_names @> ARRAY[NEW.primary_artist_name])) THEN
+      NEW.artist_names := array_append(COALESCE(NEW.artist_names, ARRAY[]::TEXT[]), NEW.primary_artist_name);
+    END IF;
+  ELSE
+    NEW.primary_artist_name := NULL;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to update primary_artist_name when a track is inserted or updated
+CREATE TRIGGER track_primary_artist_name_update
+BEFORE INSERT OR UPDATE OF primary_artist_id ON tracks
+FOR EACH ROW
+EXECUTE FUNCTION update_primary_artist_name();
+
+-- Create function to update primary_artist_name when artist name changes
+CREATE OR REPLACE FUNCTION update_primary_artist_name_on_artist_update() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks t
+    SET primary_artist_name = NEW.name,
+        artist_names = array_replace(artist_names, OLD.name, NEW.name)
+    WHERE t.primary_artist_id = NEW.id;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to update primary_artist_name when artist name changes
+CREATE TRIGGER artist_name_update_primary_artist
+AFTER UPDATE ON artists
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_primary_artist_name_on_artist_update();
+
+-- Populate primary_artist_name for existing data
+UPDATE tracks t
+SET primary_artist_name = a.name
+FROM artists a
+WHERE t.primary_artist_id = a.id;
+
+-- Ensure primary artist names are in the artistNames array
+UPDATE tracks
+SET artist_names = array_append(artist_names, primary_artist_name)
+WHERE primary_artist_name IS NOT NULL 
+AND NOT (artist_names @> ARRAY[primary_artist_name]);
+
+-- Migrate data from artist string field to primaryArtist relation
+-- This assumes you want to create Artist records for existing artist strings
+-- and set them as the primaryArtist
+
+-- First, create a function to handle the migration
+CREATE OR REPLACE FUNCTION migrate_artist_string_to_relation() RETURNS void AS $$
+DECLARE
+  artist_name text;
+  artist_id uuid;
+  track_record record;
+BEGIN
+  -- Loop through all tracks with non-null artist field
+  FOR track_record IN 
+    SELECT id, artist FROM tracks 
+    WHERE artist IS NOT NULL AND artist <> ''
+  LOOP
+    -- Check if an artist with this name already exists
+    SELECT id INTO artist_id FROM artists WHERE name = track_record.artist LIMIT 1;
+    
+    -- If not, create a new artist
+    IF artist_id IS NULL THEN
+      artist_id := gen_random_uuid();
+      INSERT INTO artists (id, name, created_at, updated_at)
+      VALUES (artist_id, track_record.artist, NOW(), NOW());
+    END IF;
+    
+    -- Update the track with the artist relation
+    UPDATE tracks t
+    SET primary_artist_id = artist_id,
+        primary_artist_name = track_record.artist,
+        artist_names = CASE 
+                         WHEN artist_names @> ARRAY[track_record.artist] THEN artist_names
+                         ELSE array_append(COALESCE(artist_names, ARRAY[]::TEXT[]), track_record.artist)
+                       END
+    WHERE t.id = track_record.id;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Execute the migration function
+-- Uncomment this line when ready to migrate data
+-- SELECT migrate_artist_string_to_relation(); 

--- a/packages/core-storage/prisma/migrations/20250304005246_remove_artist_string/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304005246_remove_artist_string/migration.sql
@@ -1,0 +1,12 @@
+-- This migration removes the artist string column after data has been migrated
+-- to the primaryArtist relation and primaryArtistName denormalized field
+
+-- First, make sure the migration function has been executed
+-- Uncomment this line if it wasn't run in the previous migration
+-- SELECT migrate_artist_string_to_relation();
+
+-- Remove the index that references the artist column
+DROP INDEX IF EXISTS "tracks_status_user_id_artist_created_at_id_idx";
+
+-- Remove the artist column
+ALTER TABLE "tracks" DROP COLUMN "artist"; 

--- a/packages/core-storage/prisma/migrations/20250304005247_make_primary_artist_required/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304005247_make_primary_artist_required/migration.sql
@@ -1,0 +1,38 @@
+-- This migration makes the primary_artist_id field required after data migration
+
+-- First, make sure all tracks have a primary artist
+-- This will identify any tracks without a primary artist
+-- SELECT id, title FROM tracks WHERE primary_artist_id IS NULL;
+
+-- If there are any tracks without a primary artist, you might want to:
+-- 1. Create a default "Unknown Artist" record
+-- 2. Assign all tracks without a primary artist to this record
+
+-- Create an "Unknown Artist" if it doesn't exist
+DO $$
+DECLARE
+  unknown_artist_id uuid;
+BEGIN
+  -- Check if "Unknown Artist" already exists
+  SELECT id INTO unknown_artist_id FROM artists WHERE name = 'Unknown Artist' LIMIT 1;
+  
+  -- If not, create it
+  IF unknown_artist_id IS NULL THEN
+    unknown_artist_id := gen_random_uuid();
+    INSERT INTO artists (id, name, created_at, updated_at)
+    VALUES (unknown_artist_id, 'Unknown Artist', NOW(), NOW());
+  END IF;
+  
+  -- Assign all tracks without a primary artist to "Unknown Artist"
+  UPDATE tracks
+  SET primary_artist_id = unknown_artist_id,
+      primary_artist_name = 'Unknown Artist',
+      artist_names = CASE 
+                       WHEN artist_names @> ARRAY['Unknown Artist'] THEN artist_names
+                       ELSE array_append(COALESCE(artist_names, ARRAY[]::TEXT[]), 'Unknown Artist')
+                     END
+  WHERE primary_artist_id IS NULL;
+END $$;
+
+-- Now make the primary_artist_id field NOT NULL
+ALTER TABLE "tracks" ALTER COLUMN "primary_artist_id" SET NOT NULL; 

--- a/packages/core-storage/prisma/migrations/20250304235553_add_search_vector/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250304235553_add_search_vector/migration.sql
@@ -1,0 +1,155 @@
+-- PostgreSQL Full-Text Search Implementation for Track Model
+-- This file contains SQL statements to set up full-text search for the Track model
+
+-- 1. Add columns to the tracks table
+ALTER TABLE tracks 
+  ADD COLUMN search_vector tsvector,
+  ADD COLUMN search_config_hash text;
+
+-- 2. Create a function to generate a hash of searchable fields
+CREATE OR REPLACE FUNCTION get_track_search_hash(
+  title text,
+  primary_artist_name text,
+  description text,
+  lyrics text,
+  artist_names text[],
+  genre_names text[],
+  mood_names text[],
+  tag_names text[]
+) RETURNS text AS $$
+  -- Use concat_ws() instead of multiple || operations (more efficient)
+  -- Use md5() instead of sha256() (faster, and collision risk is acceptable for this use case)
+  SELECT md5(concat_ws('|',
+    COALESCE(title, ''),
+    COALESCE(primary_artist_name, ''),
+    COALESCE(description, ''),
+    COALESCE(lyrics, ''),
+    -- Use array_to_string() with a simpler separator
+    COALESCE(array_to_string(artist_names, ','), ''),
+    COALESCE(array_to_string(genre_names, ','), ''),
+    COALESCE(array_to_string(mood_names, ','), ''),
+    COALESCE(array_to_string(tag_names, ','), '')
+  ));
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+
+-- 3. Create a function to update the search vector
+CREATE OR REPLACE FUNCTION tracks_search_vector_update() RETURNS trigger AS $$
+DECLARE
+  new_hash text;
+BEGIN
+  -- Calculate hash of new values
+  new_hash := get_track_search_hash(
+    NEW.title,
+    NEW.primary_artist_name,
+    NEW.description,
+    NEW.lyrics,
+    NEW.artist_names,
+    NEW.genre_names,
+    NEW.mood_names,
+    NEW.tag_names
+  );
+
+  -- Only update search vector if it's a new record or if the hash changed
+  IF (TG_OP = 'INSERT') OR (NEW.search_config_hash IS DISTINCT FROM new_hash) THEN
+    NEW.search_vector :=
+      setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(NEW.primary_artist_name, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(NEW.description, '')), 'B') ||
+      setweight(to_tsvector('english', COALESCE(NEW.lyrics, '')), 'C') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(NEW.artist_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(NEW.genre_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(NEW.mood_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(NEW.tag_names, ARRAY[]::text[]), ' ')), 'C');
+    
+    NEW.search_config_hash := new_hash;
+  END IF;
+  
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+-- 4. Create a trigger to automatically update the search vector when a track is inserted or updated
+CREATE TRIGGER tracks_search_vector_update
+BEFORE INSERT OR UPDATE ON tracks
+FOR EACH ROW
+EXECUTE FUNCTION tracks_search_vector_update();
+
+-- 5. Create a GIN index on the search vector for faster searching
+CREATE INDEX tracks_search_idx ON tracks USING GIN (search_vector);
+
+-- 6. Create an index on the search config hash
+CREATE INDEX tracks_search_config_hash_idx ON tracks (search_config_hash);
+
+-- 7. Example query to search tracks
+-- This query searches for tracks matching 'electronic dance' and ranks results by relevance
+/*
+SELECT id, title, primary_artist_name, ts_rank(search_vector, query) AS rank
+FROM tracks, to_tsquery('english', 'electronic & dance') query
+WHERE search_vector @@ query
+ORDER BY rank DESC
+LIMIT 10;
+*/
+
+-- 7. Example query with additional filters
+/*
+SELECT t.id, t.title, t.primary_artist_name, ts_rank(t.search_vector, query) AS rank
+FROM tracks t
+JOIN track_genres tg ON t.id = tg.track_id
+JOIN genres g ON tg.genre_id = g.id, 
+to_tsquery('english', 'electronic & dance') query
+WHERE t.search_vector @@ query
+AND g.name = 'House'
+AND t.bpm BETWEEN 120 AND 130
+ORDER BY rank DESC
+LIMIT 10;
+*/
+
+-- 8. Example function to update search vectors for all existing tracks
+/*
+CREATE OR REPLACE FUNCTION update_all_tracks_search_vector() RETURNS void AS $$
+BEGIN
+  -- More efficient batch update that only processes each record once
+  UPDATE tracks
+  SET 
+    search_vector = 
+      setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(primary_artist_name, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(description, '')), 'B') ||
+      setweight(to_tsvector('english', COALESCE(lyrics, '')), 'C') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(artist_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(genre_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(mood_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(tag_names, ARRAY[]::text[]), ' ')), 'C'),
+    search_config_hash = get_track_search_hash(
+      title,
+      primary_artist_name,
+      description,
+      lyrics,
+      artist_names,
+      genre_names,
+      mood_names,
+      tag_names
+    );
+END
+$$ LANGUAGE plpgsql;
+*/
+
+-- Execute with: SELECT update_all_tracks_search_vector();
+
+-- Notes:
+-- 1. The weights (A, B, C, D) determine the priority of matches:
+--    - A: Highest priority (title, primaryArtistName)
+--    - B: Medium priority (description, genres, moods, artistNames)
+--    - C: Lower priority (lyrics, tags, technical details)
+--    - D: Lowest priority (not used in this example)
+--
+-- 2. This implementation uses English language for text search.
+--    For multi-language support, consider using a language detection library
+--    and storing language-specific vectors.
+--
+-- 3. Performance optimizations implemented:
+--    - Uses a hash to detect changes instead of multiple array comparisons
+--    - Hash function is marked as IMMUTABLE for better performance
+--    - Trigger only updates search vector when the hash changes
+--    - Batch update function processes all records in a single UPDATE
+--    - GIN index for efficient full-text search queries 

--- a/packages/core-storage/prisma/migrations/20250305004008_add_search_vector_maintenance_functions/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250305004008_add_search_vector_maintenance_functions/migration.sql
@@ -1,0 +1,108 @@
+-- Add maintenance functions for Track search vectors
+
+-- TODO: Consider refactoring to reduce code duplication
+-- The vector calculation logic is currently duplicated in:
+-- 1. tracks_search_vector_update() trigger function
+-- 2. update_all_tracks_search_vector() batch function
+-- 3. update_track_search_vector() single-record function
+-- Could be extracted into a common function if this needs to be updated in future
+
+-- Function to update search vectors for all tracks
+CREATE OR REPLACE FUNCTION update_all_tracks_search_vector() RETURNS void AS $$
+BEGIN
+  -- Efficient batch update that processes all records in a single UPDATE
+  UPDATE tracks
+  SET 
+    search_vector = 
+      setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(primary_artist_name, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(description, '')), 'B') ||
+      setweight(to_tsvector('english', COALESCE(lyrics, '')), 'C') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(artist_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(genre_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(mood_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(tag_names, ARRAY[]::text[]), ' ')), 'C'),
+    search_config_hash = get_track_search_hash(
+      title,
+      primary_artist_name,
+      description,
+      lyrics,
+      artist_names,
+      genre_names,
+      mood_names,
+      tag_names
+    );
+END
+$$ LANGUAGE plpgsql;
+
+-- Function to update search vector for a specific track
+CREATE OR REPLACE FUNCTION update_track_search_vector(track_id uuid) RETURNS void AS $$
+BEGIN
+  UPDATE tracks
+  SET 
+    search_vector = 
+      setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(primary_artist_name, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(description, '')), 'B') ||
+      setweight(to_tsvector('english', COALESCE(lyrics, '')), 'C') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(artist_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(genre_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(mood_names, ARRAY[]::text[]), ' ')), 'B') ||
+      setweight(to_tsvector('english', array_to_string(COALESCE(tag_names, ARRAY[]::text[]), ' ')), 'C'),
+    search_config_hash = get_track_search_hash(
+      title,
+      primary_artist_name,
+      description,
+      lyrics,
+      artist_names,
+      genre_names,
+      mood_names,
+      tag_names
+    )
+  WHERE id = track_id;
+END
+$$ LANGUAGE plpgsql;
+
+-- Function to verify search vector integrity
+CREATE OR REPLACE FUNCTION verify_tracks_search_vector() RETURNS TABLE(
+  id uuid,
+  title text,
+  current_hash text,
+  expected_hash text
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    t.id,
+    t.title,
+    t.search_config_hash as current_hash,
+    get_track_search_hash(
+      t.title,
+      t.primary_artist_name,
+      t.description,
+      t.lyrics,
+      t.artist_names,
+      t.genre_names,
+      t.mood_names,
+      t.tag_names
+    ) as expected_hash
+  FROM tracks t
+  WHERE t.search_config_hash IS DISTINCT FROM get_track_search_hash(
+    t.title,
+    t.primary_artist_name,
+    t.description,
+    t.lyrics,
+    t.artist_names,
+    t.genre_names,
+    t.mood_names,
+    t.tag_names
+  );
+END
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION update_all_tracks_search_vector() IS 'Updates search vectors and hashes for all tracks in a single batch operation';
+COMMENT ON FUNCTION update_track_search_vector(uuid) IS 'Updates search vector and hash for a specific track by ID';
+COMMENT ON FUNCTION verify_tracks_search_vector() IS 'Returns tracks where the current search hash does not match the expected hash based on current field values';
+
+-- Initialize search vectors and hashes for all existing tracks
+SELECT update_all_tracks_search_vector();

--- a/packages/core-storage/prisma/migrations/20250305004931_rename_indexes_and_create_pg_trgm_extension/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250305004931_rename_indexes_and_create_pg_trgm_extension/migration.sql
@@ -1,0 +1,20 @@
+-- CreateExtension
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+
+-- RenameIndex
+ALTER INDEX "idx_tracks_artist_names" RENAME TO "tracks_artist_names_idx";
+
+-- RenameIndex
+ALTER INDEX "idx_tracks_genre_names" RENAME TO "tracks_genre_names_idx";
+
+-- RenameIndex
+ALTER INDEX "idx_tracks_mood_names" RENAME TO "tracks_mood_names_idx";
+
+-- RenameIndex
+ALTER INDEX "idx_tracks_primary_artist_name" RENAME TO "tracks_primary_artist_name_idx";
+
+-- RenameIndex
+ALTER INDEX "idx_tracks_tag_names" RENAME TO "tracks_tag_names_idx";
+
+-- RenameIndex
+ALTER INDEX "tracks_search_idx" RENAME TO "tracks_search_vector_idx";

--- a/packages/core-storage/prisma/schema.prisma
+++ b/packages/core-storage/prisma/schema.prisma
@@ -45,58 +45,58 @@ enum TrackStatus {
 // Potential additional fields for Track model:
 //
 // 1. Release Information:
-// - releaseDate: DateTime - The official release date of the track
-// - originalReleaseDate: DateTime - For re-releases or remasters
-// - recordLabel: String - The record label that released the track
-// - catalogNumber: String - The label's catalog reference number
+// - [ ] releaseDate: DateTime - The official release date of the track
+// - [ ] originalReleaseDate: DateTime - For re-releases or remasters
+// - [ ] recordLabel: String - The record label that released the track
+// - [ ] catalogNumber: String - The label's catalog reference number
 //
 // 2. Musical Information:
-// - bpm: Float - Beats per minute
-// - key: String - Musical key of the track
-// - isrc: String - International Standard Recording Code
-// - genre: String[] - Multiple genres can be applicable
-// - mood: String[] - Emotional categorization (e.g., "energetic", "melancholic")
-// - language: String - Language of the lyrics
+// - [ ] bpm: Float - Beats per minute
+// - [ ] key: String - Musical key of the track
+// - [ ] isrc: String - International Standard Recording Code
+// - [ ] genre: String[] - Multiple genres can be applicable
+// - [ ] mood: String[] - Emotional categorization (e.g., "energetic", "melancholic")
+// - [ ] language: String - Language of the lyrics
 //
 // 3. Credits:
-// - composers: String[] - Song writers
-// - producers: String[] - Track producers
-// - features: String[] - Featured artists
-// - performers: String[] - Session musicians or band members
-// - credits: Json - Detailed production credits
+// - [ ] composers: String[] - Song writers
+// - [ ] producers: String[] - Track producers
+// - [ ] features: String[] - Featured artists
+// - [ ] performers: String[] - Session musicians or band members
+// - [ ] credits: Json - Detailed production credits
 //
 // 4. Technical Information:
-// - replayGain: Float - Volume normalization value
-// - peakAmplitude: Float - Maximum amplitude in the track
-// - encodingTechnology: String - Original recording technology
-// - recordingLocation: String - Studio or venue where recorded
-// - mixEngineer: String - Mix engineer name
-// - masteringEngineer: String - Mastering engineer name
+// - [ ] replayGain: Float - Volume normalization value
+// - [ ] peakAmplitude: Float - Maximum amplitude in the track
+// - [ ] encodingTechnology: String - Original recording technology
+// - [ ] recordingLocation: String - Studio or venue where recorded
+// - [ ] mixEngineer: String - Mix engineer name
+// - [ ] masteringEngineer: String - Mastering engineer name
 //
 // 5. Commercial/Rights:
-// - copyright: String - Copyright notice
-// - license: String - Licensing terms
-// - publisher: String - Music publisher
-// - pLine: String - Phonographic copyright line
-// - cLine: String - Copyright line
+// - [ ] copyright: String - Copyright notice
+// - [ ] license: String - Licensing terms
+// - [ ] publisher: String - Music publisher
+// - [ ] pLine: String - Phonographic copyright line
+// - [ ] cLine: String - Copyright line
 //
 // 6. Additional Metadata:
-// - lyrics: String - Song lyrics
-// - description: String - Track description or notes
-// - tags: String[] - Searchable keywords
-// - explicit: Boolean - Whether the track contains explicit content
-// - remixedBy: String - For remix versions
-// - version: String - Type of version (e.g., "Radio Edit", "Extended Mix")
-// - partOfAlbum: Boolean - Whether the track belongs to an album
-// - albumName: String - Name of the album if applicable
-// - trackNumber: Int - Position in album if applicable
-// - discNumber: Int - For multi-disc albums
+// - [ ] lyrics: String - Song lyrics
+// - [ ] description: String - Track description or notes
+// - [ ] tags: String[] - Searchable keywords
+// - [ ] explicit: Boolean - Whether the track contains explicit content
+// - [ ] remixedBy: String - For remix versions
+// - [ ] version: String - Type of version (e.g., "Radio Edit", "Extended Mix")
+// - [ ] partOfAlbum: Boolean - Whether the track belongs to an album
+// - [ ] albumName: String - Name of the album if applicable
+// - [ ] trackNumber: Int - Position in album if applicable
+// - [ ] discNumber: Int - For multi-disc albums
 //
 // These fields follow standards from:
-// - ID3 tags (the metadata standard for MP3s)
-// - MusicBrainz database schema
-// - Streaming platform metadata systems
-// - Industry-standard music databases like Gracenote
+// - [ ] ID3 tags (the metadata standard for MP3s)
+// - [ ] MusicBrainz database schema
+// - [ ] Streaming platform metadata systems
+// - [ ] Industry-standard music databases like Gracenote
 
 // TODO: The Url suffixes should be removed/replaced, as the values stored are not URLs (with
 // the exception of originalUrl, which is a file:// URL until the track is converted).

--- a/packages/core-storage/prisma/schema/denormalized_arrays.sql
+++ b/packages/core-storage/prisma/schema/denormalized_arrays.sql
@@ -1,0 +1,250 @@
+-- Denormalized Arrays for Efficient Filtering
+-- This file contains SQL statements to implement denormalized arrays for many-to-many relationships
+
+-- 1. Add array columns to the tracks table
+ALTER TABLE tracks ADD COLUMN genre_names TEXT[] DEFAULT '{}';
+ALTER TABLE tracks ADD COLUMN mood_names TEXT[] DEFAULT '{}';
+ALTER TABLE tracks ADD COLUMN artist_names TEXT[] DEFAULT '{}';
+ALTER TABLE tracks ADD COLUMN tag_names TEXT[] DEFAULT '{}';
+
+-- 2. Create GIN indexes on the array columns for efficient filtering
+CREATE INDEX idx_tracks_genre_names ON tracks USING GIN (genre_names);
+CREATE INDEX idx_tracks_mood_names ON tracks USING GIN (mood_names);
+CREATE INDEX idx_tracks_artist_names ON tracks USING GIN (artist_names);
+CREATE INDEX idx_tracks_tag_names ON tracks USING GIN (tag_names);
+
+-- 3. Create functions and triggers to keep the arrays in sync with the related tables
+
+-- Genre Names
+CREATE OR REPLACE FUNCTION update_track_genre_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET genre_names = array_append(genre_names, (SELECT name FROM genres WHERE id = NEW.genre_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET genre_names = array_remove(genre_names, (SELECT name FROM genres WHERE id = OLD.genre_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_genre_names_update
+AFTER INSERT OR DELETE ON track_genres
+FOR EACH ROW
+EXECUTE FUNCTION update_track_genre_names();
+
+-- Mood Names
+CREATE OR REPLACE FUNCTION update_track_mood_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET mood_names = array_append(mood_names, (SELECT name FROM moods WHERE id = NEW.mood_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET mood_names = array_remove(mood_names, (SELECT name FROM moods WHERE id = OLD.mood_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_mood_names_update
+AFTER INSERT OR DELETE ON track_moods
+FOR EACH ROW
+EXECUTE FUNCTION update_track_mood_names();
+
+-- Artist Names (from TrackCredit)
+CREATE OR REPLACE FUNCTION update_track_artist_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET artist_names = array_append(artist_names, (SELECT name FROM artists WHERE id = NEW.artist_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET artist_names = array_remove(artist_names, (SELECT name FROM artists WHERE id = OLD.artist_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_artist_names_update
+AFTER INSERT OR DELETE ON track_credits
+FOR EACH ROW
+EXECUTE FUNCTION update_track_artist_names();
+
+-- Tag Names
+CREATE OR REPLACE FUNCTION update_track_tag_names() RETURNS TRIGGER AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE tracks
+    SET tag_names = array_append(tag_names, (SELECT name FROM tags WHERE id = NEW.tag_id))
+    WHERE id = NEW.track_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE tracks
+    SET tag_names = array_remove(tag_names, (SELECT name FROM tags WHERE id = OLD.tag_id))
+    WHERE id = OLD.track_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER track_tag_names_update
+AFTER INSERT OR DELETE ON track_tags
+FOR EACH ROW
+EXECUTE FUNCTION update_track_tag_names();
+
+-- 4. Handle updates to the name fields in the related tables
+
+-- Genre Name Updates
+CREATE OR REPLACE FUNCTION update_genre_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET genre_names = array_replace(genre_names, OLD.name, NEW.name)
+    WHERE genre_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER genre_name_update
+AFTER UPDATE ON genres
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_genre_name_in_tracks();
+
+-- Mood Name Updates
+CREATE OR REPLACE FUNCTION update_mood_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET mood_names = array_replace(mood_names, OLD.name, NEW.name)
+    WHERE mood_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER mood_name_update
+AFTER UPDATE ON moods
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_mood_name_in_tracks();
+
+-- Artist Name Updates
+CREATE OR REPLACE FUNCTION update_artist_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET artist_names = array_replace(artist_names, OLD.name, NEW.name)
+    WHERE artist_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER artist_name_update
+AFTER UPDATE ON artists
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_artist_name_in_tracks();
+
+-- Tag Name Updates
+CREATE OR REPLACE FUNCTION update_tag_name_in_tracks() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.name <> OLD.name THEN
+    UPDATE tracks
+    SET tag_names = array_replace(tag_names, OLD.name, NEW.name)
+    WHERE tag_names @> ARRAY[OLD.name];
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tag_name_update
+AFTER UPDATE ON tags
+FOR EACH ROW
+WHEN (NEW.name <> OLD.name)
+EXECUTE FUNCTION update_tag_name_in_tracks();
+
+-- 5. Function to populate the arrays for existing data
+CREATE OR REPLACE FUNCTION populate_track_array_fields() RETURNS void AS $$
+BEGIN
+  -- Populate genre_names
+  UPDATE tracks t
+  SET genre_names = ARRAY(
+    SELECT g.name
+    FROM genres g
+    JOIN track_genres tg ON g.id = tg.genre_id
+    WHERE tg.track_id = t.id
+  );
+  
+  -- Populate mood_names
+  UPDATE tracks t
+  SET mood_names = ARRAY(
+    SELECT m.name
+    FROM moods m
+    JOIN track_moods tm ON m.id = tm.mood_id
+    WHERE tm.track_id = t.id
+  );
+  
+  -- Populate artist_names
+  UPDATE tracks t
+  SET artist_names = ARRAY(
+    SELECT a.name
+    FROM artists a
+    JOIN track_credits tc ON a.id = tc.artist_id
+    WHERE tc.track_id = t.id
+  );
+  
+  -- Populate tag_names
+  UPDATE tracks t
+  SET tag_names = ARRAY(
+    SELECT tg.name
+    FROM tags tg
+    JOIN track_tags tt ON tg.id = tt.tag_id
+    WHERE tt.track_id = t.id
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+-- Execute with: SELECT populate_track_array_fields();
+
+-- 6. Example queries for filtering using the denormalized arrays
+
+/*
+-- Find tracks with specific genres
+SELECT * FROM tracks
+WHERE genre_names && ARRAY['House', 'Techno']
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Find tracks with specific moods and BPM range
+SELECT * FROM tracks
+WHERE mood_names && ARRAY['Energetic', 'Happy']
+AND bpm BETWEEN 120 AND 130
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Find tracks with specific artists and tags
+SELECT * FROM tracks
+WHERE artist_names && ARRAY['Artist Name']
+AND tag_names && ARRAY['Summer', 'Dance']
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- Combine with full-text search
+SELECT *, ts_rank(search_vector, to_tsquery('english', 'dance')) AS rank
+FROM tracks
+WHERE search_vector @@ to_tsquery('english', 'dance')
+AND genre_names && ARRAY['House']
+AND bpm > 120
+ORDER BY rank DESC
+LIMIT 20;
+*/ 

--- a/packages/core-storage/prisma/schema/full_text_search.sql
+++ b/packages/core-storage/prisma/schema/full_text_search.sql
@@ -1,0 +1,91 @@
+-- PostgreSQL Full-Text Search Implementation for Track Model
+-- This file contains SQL statements to set up full-text search for the Track model
+
+-- 1. Add a tsvector column to the tracks table
+ALTER TABLE tracks ADD COLUMN search_vector tsvector;
+
+-- 2. Create a function to update the search vector
+CREATE OR REPLACE FUNCTION tracks_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') ||
+    setweight(to_tsvector('english', COALESCE(NEW.artist, '')), 'A') ||
+    setweight(to_tsvector('english', COALESCE(NEW.description, '')), 'B') ||
+    setweight(to_tsvector('english', COALESCE(NEW.lyrics, '')), 'C');
+  
+  -- Add more fields as needed, for example:
+  -- setweight(to_tsvector('english', (SELECT string_agg(g.name, ' ') FROM genres g JOIN track_genres tg ON g.id = tg.genre_id WHERE tg.track_id = NEW.id)), 'B') ||
+  -- setweight(to_tsvector('english', COALESCE(NEW.version, '')), 'C') ||
+  -- setweight(to_tsvector('english', COALESCE(NEW.remixed_by, '')), 'C');
+  
+  RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+-- 3. Create a trigger to automatically update the search vector when a track is inserted or updated
+CREATE TRIGGER tracks_search_vector_update
+BEFORE INSERT OR UPDATE ON tracks
+FOR EACH ROW
+EXECUTE FUNCTION tracks_search_vector_update();
+
+-- 4. Create a GIN index on the search vector for faster searching
+CREATE INDEX tracks_search_idx ON tracks USING GIN (search_vector);
+
+-- 5. Example query to search tracks
+-- This query searches for tracks matching 'electronic dance' and ranks results by relevance
+/*
+SELECT id, title, artist, ts_rank(search_vector, query) AS rank
+FROM tracks, to_tsquery('english', 'electronic & dance') query
+WHERE search_vector @@ query
+ORDER BY rank DESC
+LIMIT 10;
+*/
+
+-- 6. Example query with additional filters
+/*
+SELECT t.id, t.title, t.artist, ts_rank(t.search_vector, query) AS rank
+FROM tracks t
+JOIN track_genres tg ON t.id = tg.track_id
+JOIN genres g ON tg.genre_id = g.id, 
+to_tsquery('english', 'electronic & dance') query
+WHERE t.search_vector @@ query
+AND g.name = 'House'
+AND t.bpm BETWEEN 120 AND 130
+ORDER BY rank DESC
+LIMIT 10;
+*/
+
+-- 7. Example function to update search vectors for all existing tracks
+/*
+CREATE OR REPLACE FUNCTION update_all_tracks_search_vector() RETURNS void AS $$
+DECLARE
+  track_record RECORD;
+BEGIN
+  FOR track_record IN SELECT * FROM tracks LOOP
+    UPDATE tracks
+    SET search_vector = 
+      setweight(to_tsvector('english', COALESCE(track_record.title, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(track_record.artist, '')), 'A') ||
+      setweight(to_tsvector('english', COALESCE(track_record.description, '')), 'B') ||
+      setweight(to_tsvector('english', COALESCE(track_record.lyrics, '')), 'C')
+    WHERE id = track_record.id;
+  END LOOP;
+END
+$$ LANGUAGE plpgsql;
+
+-- Execute with: SELECT update_all_tracks_search_vector();
+*/
+
+-- Notes:
+-- 1. The weights (A, B, C, D) determine the priority of matches:
+--    - A: Highest priority (title, artist)
+--    - B: Medium priority (description, genres)
+--    - C: Lower priority (lyrics, technical details)
+--    - D: Lowest priority (not used in this example)
+--
+-- 2. This implementation uses English language for text search.
+--    For multi-language support, consider using a language detection library
+--    and storing language-specific vectors.
+--
+-- 3. For very large tables, consider using a materialized view or
+--    a separate search table that is updated asynchronously. 

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -1,12 +1,13 @@
 generator client {
   provider = "prisma-client-js"
   output   = "../../node_modules/.prisma/client"
-  previewFeatures = ["prismaSchemaFolder"]
+  previewFeatures = ["prismaSchemaFolder", "postgresqlExtensions"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [pg_trgm]
 }
 
 model User {
@@ -190,7 +191,8 @@ model Track {
   
   // Full-text search field (can be maintained by a trigger in PostgreSQL)
   // Note: This requires custom SQL as Prisma doesn't directly support tsvector
-  // searchVector        Unsupported("tsvector")?  @map("search_vector")
+  searchVector        Unsupported("tsvector")?  @map("search_vector")
+  searchConfigHash    String?                   @map("search_config_hash")
 
   // TODO: Audit these indexes and remove any that are not needed.
   @@index([originalFormat, wavLastRequestedAt])
@@ -207,6 +209,8 @@ model Track {
   @@index([moodNames], type: Gin)
   @@index([artistNames], type: Gin)
   @@index([tagNames], type: Gin)
+  @@index([searchVector], type: Gin)
+  @@index([searchConfigHash])
   @@map("tracks")
 }
 

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../node_modules/.prisma/client"
+  output   = "../../node_modules/.prisma/client"
   previewFeatures = ["prismaSchemaFolder"]
 }
 

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -166,12 +166,18 @@ model Track {
   licenseId           String?      @map("license_id")
   license             License?     @relation(fields: [licenseId], references: [id])
   
-  // Many-to-many relationships
+  // Many-to-many relationships, plus denormalized arrays for efficient filtering
   genres              TrackGenre[]
+  genreNames          String[]     @default([]) @map("genre_names")
   albums              TrackAlbum[]
+  // TODO: Add denormalized array for album names if needed
   credits             TrackCredit[]
+  // artistNames is denormalized from Artist via TrackCredit
+  artistNames         String[]     @default([]) @map("artist_names")
   moods               TrackMood[]
+  moodNames           String[]     @default([]) @map("mood_names")
   tags                TrackTag[]
+  tagNames            String[]     @default([]) @map("tag_names")
   
   // Full-text search field (can be maintained by a trigger in PostgreSQL)
   // Note: This requires custom SQL as Prisma doesn't directly support tsvector

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -190,7 +190,7 @@ model Track {
   
   // Full-text search field (can be maintained by a trigger in PostgreSQL)
   // Note: This requires custom SQL as Prisma doesn't directly support tsvector
-  // searchVector       Unsupported("tsvector")?  @map("search_vector")
+  // searchVector        Unsupported("tsvector")?  @map("search_vector")
 
   // TODO: Audit these indexes and remove any that are not needed.
   @@index([originalFormat, wavLastRequestedAt])
@@ -198,9 +198,15 @@ model Track {
   @@index([id, status])
   @@index([status, userId, title, createdAt, id])
   @@index([status, userId, primaryArtistId, createdAt, id])
-  @@index([status, userId, primaryArtistName, createdAt, id])
+  // TODO: Add this index if it's needed for sorting:
+  // @@index([status, userId, primaryArtistName, createdAt, id])
   @@index([status, userId, duration, createdAt, id])
   @@index([status, isPublic, createdAt, id])
+  @@index([primaryArtistName])
+  @@index([genreNames], type: Gin)
+  @@index([moodNames], type: Gin)
+  @@index([artistNames], type: Gin)
+  @@index([tagNames], type: Gin)
   @@map("tracks")
 }
 

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -137,9 +137,11 @@ model Track {
   isExplicit          Boolean      @default(false) @map("is_explicit")
   
   // Release Information
-  releaseDate         DateTime?    @map("release_date")
-  originalReleaseDate DateTime?    @map("original_release_date")
-  catalogNumber       String?      @map("catalog_number")
+  releaseDate                   DateTime?                     @map("release_date")
+  releaseDatePrecision          DatePrecision?  @default(DAY) @map("release_date_precision")
+  originalReleaseDate           DateTime?                     @map("original_release_date")
+  originalReleaseDatePrecision  DatePrecision?  @default(DAY) @map("original_release_date_precision")
+  catalogNumber                 String?                       @map("catalog_number")
   
   // Commercial/Rights Information
   copyright           String?
@@ -317,4 +319,10 @@ enum AudioFileConversionStatus {
   IN_PROGRESS
   COMPLETED
   FAILED
+}
+
+enum DatePrecision {
+  YEAR
+  MONTH
+  DAY
 }

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -107,6 +107,8 @@ model Track {
   primaryArtistId       String                     @map("primary_artist_id")
   primaryArtist         Artist                     @relation("PrimaryArtist", fields: [primaryArtistId], references: [id])
   // primaryArtistName is denormalized from Artist
+  // See packages/core-storage/prisma/migrations/20250304005245_add_primary_artist_name/migration.sql
+  // for the trigger that keeps the primaryArtistName field in sync with the primaryArtistId field.
   primaryArtistName     String?                    @map("primary_artist_name")
   originalFormat        SourceFormat               @map("original_format")
   originalUrl           String                     @map("original_url")
@@ -170,6 +172,10 @@ model Track {
   license             License?     @relation(fields: [licenseId], references: [id])
   
   // Many-to-many relationships, plus denormalized arrays for efficient filtering
+  // See packages/core-storage/prisma/migrations/20250304005244_add_denormalized_arrays/migration.sql
+  // and packages/core-storage/prisma/migrations/20250304005245_add_primary_artist_name/migration.sql
+  // for triggers that keep the denormalized arrays in sync with the related tables,
+  // and GIN indexes on the arrays for efficient filtering.
   genres              TrackGenre[]
   genreNames          String[]     @default([]) @map("genre_names")
   albums              TrackAlbum[]

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -104,7 +104,10 @@ enum TrackStatus {
 model Track {
   id                    String                     @id @default(uuid())
   title                 String
-  artist                String
+  primaryArtistId       String                     @map("primary_artist_id")
+  primaryArtist         Artist                     @relation("PrimaryArtist", fields: [primaryArtistId], references: [id])
+  // primaryArtistName is denormalized from Artist
+  primaryArtistName     String?                    @map("primary_artist_name")
   originalFormat        SourceFormat               @map("original_format")
   originalUrl           String                     @map("original_url")
   fullTrackWavUrl       String?                    @map("full_track_wav_url")
@@ -172,7 +175,7 @@ model Track {
   albums              TrackAlbum[]
   // TODO: Add denormalized array for album names if needed
   credits             TrackCredit[]
-  // artistNames is denormalized from Artist via TrackCredit
+  // artistNames is denormalized from Artist via TrackCredit and from the primaryArtistName field
   artistNames         String[]     @default([]) @map("artist_names")
   moods               TrackMood[]
   moodNames           String[]     @default([]) @map("mood_names")
@@ -188,7 +191,8 @@ model Track {
   @@index([originalFormat, flacLastRequestedAt])
   @@index([id, status])
   @@index([status, userId, title, createdAt, id])
-  @@index([status, userId, artist, createdAt, id])
+  @@index([status, userId, primaryArtistId, createdAt, id])
+  @@index([status, userId, primaryArtistName, createdAt, id])
   @@index([status, userId, duration, createdAt, id])
   @@index([status, isPublic, createdAt, id])
   @@map("tracks")

--- a/packages/core-storage/prisma/schema/schema.prisma
+++ b/packages/core-storage/prisma/schema/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider = "prisma-client-js"
   output   = "../node_modules/.prisma/client"
+  previewFeatures = ["prismaSchemaFolder"]
 }
 
 datasource db {
@@ -127,6 +128,52 @@ model Track {
   wavLastRequestedAt    DateTime?                  @map("wav_last_requested_at")
   flacCreatedAt         DateTime?                  @map("flac_created_at")
   flacLastRequestedAt   DateTime?                  @map("flac_last_requested_at")
+
+    // Musical Information
+  bpm                 Float?
+  key                 String?
+  isrc                String?      @map("isrc") // International Standard Recording Code
+  language            String?
+  isExplicit          Boolean      @default(false) @map("is_explicit")
+  
+  // Release Information
+  releaseDate         DateTime?    @map("release_date")
+  originalReleaseDate DateTime?    @map("original_release_date")
+  catalogNumber       String?      @map("catalog_number")
+  
+  // Commercial/Rights Information
+  copyright           String?
+  pLine               String?      @map("p_line") // Phonographic copyright line
+  cLine               String?      @map("c_line") // Copyright line
+  
+  // Additional Metadata
+  lyrics              String?
+  description         String?
+  version             String?      // e.g., "Radio Edit", "Extended Mix"
+  remixedBy           String?      @map("remixed_by")
+  
+  // Technical Information
+  replayGain          Float?       @map("replay_gain")
+  peakAmplitude       Float?       @map("peak_amplitude")
+  encodingTechnology  String?      @map("encoding_technology")
+  recordingLocation   String?      @map("recording_location")
+  
+  // Relationships to normalized tables
+  recordLabelId       String?      @map("record_label_id")
+  recordLabel         RecordLabel? @relation(fields: [recordLabelId], references: [id])
+  licenseId           String?      @map("license_id")
+  license             License?     @relation(fields: [licenseId], references: [id])
+  
+  // Many-to-many relationships
+  genres              TrackGenre[]
+  albums              TrackAlbum[]
+  credits             TrackCredit[]
+  moods               TrackMood[]
+  tags                TrackTag[]
+  
+  // Full-text search field (can be maintained by a trigger in PostgreSQL)
+  // Note: This requires custom SQL as Prisma doesn't directly support tsvector
+  // searchVector       Unsupported("tsvector")?  @map("search_vector")
 
   // TODO: Audit these indexes and remove any that are not needed.
   @@index([originalFormat, wavLastRequestedAt])

--- a/packages/core-storage/prisma/schema/track_extensions.prisma
+++ b/packages/core-storage/prisma/schema/track_extensions.prisma
@@ -1,0 +1,179 @@
+// This file contains extensions to the Track model and related entities
+// It is meant to be used alongside the main schema.prisma file
+
+// Record Label - A company that publishes and promotes music
+model RecordLabel {
+  id          String    @id @default(uuid())
+  name        String    @unique
+  website     String?
+  logoUrl     String?   @map("logo_url")
+  description String?
+  tracks      Track[]
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
+  
+  @@map("record_labels")
+}
+
+// Genre - Musical classification
+model Genre {
+  id          String       @id @default(uuid())
+  name        String       @unique
+  description String?
+  tracks      TrackGenre[]
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
+  
+  @@map("genres")
+}
+
+// TrackGenre - Many-to-many relationship between Track and Genre
+model TrackGenre {
+  id        String   @id @default(uuid())
+  trackId   String   @map("track_id")
+  track     Track    @relation(fields: [trackId], references: [id])
+  genreId   String   @map("genre_id")
+  genre     Genre    @relation(fields: [genreId], references: [id])
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([trackId, genreId])
+  @@map("track_genres")
+}
+
+// Album - Collection of tracks
+model Album {
+  id          String       @id @default(uuid())
+  title       String
+  releaseDate DateTime?    @map("release_date")
+  coverArtUrl String?      @map("cover_art_url")
+  description String?
+  tracks      TrackAlbum[]
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
+  
+  @@map("albums")
+}
+
+// TrackAlbum - Many-to-many relationship between Track and Album
+model TrackAlbum {
+  id          String   @id @default(uuid())
+  trackId     String   @map("track_id")
+  track       Track    @relation(fields: [trackId], references: [id])
+  albumId     String   @map("album_id")
+  album       Album    @relation(fields: [albumId], references: [id])
+  trackNumber Int?     @map("track_number")
+  discNumber  Int?     @map("disc_number")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@unique([trackId, albumId])
+  @@map("track_albums")
+}
+
+// Artist - A person or group who creates or performs music
+model Artist {
+  id             String           @id @default(uuid())
+  name           String
+  bio            String?
+  imageUrl       String?          @map("image_url")
+  website        String?
+  trackCredits   TrackCredit[]
+  createdAt      DateTime         @default(now()) @map("created_at")
+  updatedAt      DateTime         @updatedAt @map("updated_at")
+  
+  @@map("artists")
+}
+
+// Credit types for track contributors
+enum CreditType {
+  COMPOSER
+  PRODUCER
+  FEATURED_ARTIST
+  PERFORMER
+  MIX_ENGINEER
+  MASTERING_ENGINEER
+  LYRICIST
+  ARRANGER
+}
+
+// TrackCredit - Relationship between Track and Artist with role
+model TrackCredit {
+  id        String     @id @default(uuid())
+  trackId   String     @map("track_id")
+  track     Track      @relation(fields: [trackId], references: [id])
+  artistId  String     @map("artist_id")
+  artist    Artist     @relation(fields: [artistId], references: [id])
+  creditType CreditType @map("credit_type")
+  role      String?    // Optional specific role description
+  createdAt DateTime   @default(now()) @map("created_at")
+  updatedAt DateTime   @updatedAt @map("updated_at")
+
+  @@unique([trackId, artistId, creditType])
+  @@map("track_credits")
+}
+
+// Mood - Emotional categorization of tracks
+model Mood {
+  id          String      @id @default(uuid())
+  name        String      @unique
+  description String?
+  tracks      TrackMood[]
+  createdAt   DateTime    @default(now()) @map("created_at")
+  updatedAt   DateTime    @updatedAt @map("updated_at")
+  
+  @@map("moods")
+}
+
+// TrackMood - Many-to-many relationship between Track and Mood
+model TrackMood {
+  id        String   @id @default(uuid())
+  trackId   String   @map("track_id")
+  track     Track    @relation(fields: [trackId], references: [id])
+  moodId    String   @map("mood_id")
+  mood      Mood     @relation(fields: [moodId], references: [id])
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([trackId, moodId])
+  @@map("track_moods")
+}
+
+// Tag - Searchable keywords for tracks
+model Tag {
+  id          String     @id @default(uuid())
+  name        String     @unique
+  description String?
+  tracks      TrackTag[]
+  createdAt   DateTime   @default(now()) @map("created_at")
+  updatedAt   DateTime   @updatedAt @map("updated_at")
+  
+  @@map("tags")
+}
+
+// TrackTag - Many-to-many relationship between Track and Tag
+model TrackTag {
+  id        String   @id @default(uuid())
+  trackId   String   @map("track_id")
+  track     Track    @relation(fields: [trackId], references: [id])
+  tagId     String   @map("tag_id")
+  tag       Tag      @relation(fields: [tagId], references: [id])
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@unique([trackId, tagId])
+  @@map("track_tags")
+}
+
+// License - Legal terms for track usage
+model License {
+  id          String   @id @default(uuid())
+  name        String   @unique
+  description String?
+  terms       String?
+  tracks      Track[]
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+  
+  @@map("licenses")
+} 

--- a/packages/core-storage/prisma/schema/track_extensions.prisma
+++ b/packages/core-storage/prisma/schema/track_extensions.prisma
@@ -45,6 +45,7 @@ model TrackGenre {
 model Album {
   id          String       @id @default(uuid())
   title       String
+  // TODO: Add release date precision
   releaseDate DateTime?    @map("release_date")
   coverArtUrl String?      @map("cover_art_url")
   description String?

--- a/packages/core-storage/prisma/schema/track_extensions.prisma
+++ b/packages/core-storage/prisma/schema/track_extensions.prisma
@@ -73,15 +73,16 @@ model TrackAlbum {
 }
 
 // Artist - A person or group who creates or performs music
-model Artist {
-  id             String           @id @default(uuid())
-  name           String
-  bio            String?
-  imageUrl       String?          @map("image_url")
-  website        String?
-  trackCredits   TrackCredit[]
-  createdAt      DateTime         @default(now()) @map("created_at")
-  updatedAt      DateTime         @updatedAt @map("updated_at")
+model Artist {    
+  id                String        @id @default(uuid())
+  name              String
+  bio               String?
+  imageUrl          String?                       @map("image_url")
+  website           String?
+  trackCredits      TrackCredit[]
+  primaryForTracks  Track[]       @relation("PrimaryArtist")
+  createdAt         DateTime      @default(now()) @map("created_at")
+  updatedAt         DateTime      @updatedAt      @map("updated_at")
   
   @@map("artists")
 }

--- a/packages/core-storage/prisma/track_model_extensions.prisma
+++ b/packages/core-storage/prisma/track_model_extensions.prisma
@@ -39,12 +39,17 @@ Add these fields and relationships to the Track model in schema.prisma:
   licenseId           String?      @map("license_id")
   license             License?     @relation(fields: [licenseId], references: [id])
   
-  // Many-to-many relationships
+  // Many-to-many relationships, plus denormalized arrays for efficient filtering
   genres              TrackGenre[]
+  genreNames          String[]     @default([]) @map("genre_names")
   albums              TrackAlbum[]
+  // TODO: Add denormalized array for album names if needed
   credits             TrackCredit[]
+  artistNames         String[]     @default([]) @map("artist_names")
   moods               TrackMood[]
+  moodNames           String[]     @default([]) @map("mood_names")
   tags                TrackTag[]
+  tagNames            String[]     @default([]) @map("tag_names")
   
   // Full-text search field (can be maintained by a trigger in PostgreSQL)
   // Note: This requires custom SQL as Prisma doesn't directly support tsvector

--- a/packages/core-storage/prisma/track_model_extensions.prisma
+++ b/packages/core-storage/prisma/track_model_extensions.prisma
@@ -1,0 +1,55 @@
+// This file contains extensions to the Track model
+// It shows how the Track model should be modified to include the new fields and relationships
+
+/*
+Add these fields and relationships to the Track model in schema.prisma:
+
+  // Musical Information
+  bpm                 Float?
+  key                 String?
+  isrc                String?      @map("isrc") // International Standard Recording Code
+  language            String?
+  isExplicit          Boolean      @default(false) @map("is_explicit")
+  
+  // Release Information
+  releaseDate         DateTime?    @map("release_date")
+  originalReleaseDate DateTime?    @map("original_release_date")
+  catalogNumber       String?      @map("catalog_number")
+  
+  // Commercial/Rights Information
+  copyright           String?
+  pLine               String?      @map("p_line") // Phonographic copyright line
+  cLine               String?      @map("c_line") // Copyright line
+  
+  // Additional Metadata
+  lyrics              String?
+  description         String?
+  version             String?      // e.g., "Radio Edit", "Extended Mix"
+  remixedBy           String?      @map("remixed_by")
+  
+  // Technical Information
+  replayGain          Float?       @map("replay_gain")
+  peakAmplitude       Float?       @map("peak_amplitude")
+  encodingTechnology  String?      @map("encoding_technology")
+  recordingLocation   String?      @map("recording_location")
+  
+  // Relationships to normalized tables
+  recordLabelId       String?      @map("record_label_id")
+  recordLabel         RecordLabel? @relation(fields: [recordLabelId], references: [id])
+  licenseId           String?      @map("license_id")
+  license             License?     @relation(fields: [licenseId], references: [id])
+  
+  // Many-to-many relationships
+  genres              TrackGenre[]
+  albums              TrackAlbum[]
+  credits             TrackCredit[]
+  moods               TrackMood[]
+  tags                TrackTag[]
+  
+  // Full-text search field (can be maintained by a trigger in PostgreSQL)
+  // Note: This requires custom SQL as Prisma doesn't directly support tsvector
+  // searchVector       Unsupported("tsvector")?  @map("search_vector")
+  
+  // Extended JSON metadata for flexible storage of additional fields
+  extendedMetadata    Json?        @map("extended_metadata")
+*/ 

--- a/packages/core-storage/src/examples/track-filtering.ts
+++ b/packages/core-storage/src/examples/track-filtering.ts
@@ -1,0 +1,279 @@
+import { PrismaClient } from ".prisma/client";
+
+const prisma = new PrismaClient();
+
+/**
+ * Example functions for filtering tracks using denormalized arrays
+ */
+
+interface TrackFilterOptions {
+  searchTerm?: string;
+  genres?: string[];
+  moods?: string[];
+  artists?: string[];
+  tags?: string[];
+  bpmMin?: number;
+  bpmMax?: number;
+  key?: string;
+  isExplicit?: boolean;
+  releaseDateStart?: Date;
+  releaseDateEnd?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Filter tracks using Prisma's query API
+ * This approach works well for simple filters
+ */
+export async function filterTracks(options: TrackFilterOptions) {
+  const {
+    genres,
+    moods,
+    artists,
+    tags,
+    bpmMin,
+    bpmMax,
+    key,
+    isExplicit,
+    releaseDateStart,
+    releaseDateEnd,
+    limit = 20,
+    offset = 0,
+  } = options;
+
+  // Build the where clause
+  const where: any = {
+    status: "ACTIVE", // Only include active tracks
+  };
+
+  // Add filters for denormalized arrays
+  if (genres && genres.length > 0) {
+    where.genreNames = { hasSome: genres };
+  }
+
+  if (moods && moods.length > 0) {
+    where.moodNames = { hasSome: moods };
+  }
+
+  if (artists && artists.length > 0) {
+    where.artistNames = { hasSome: artists };
+  }
+
+  if (tags && tags.length > 0) {
+    where.tagNames = { hasSome: tags };
+  }
+
+  // Add filters for scalar fields
+  if (bpmMin !== undefined || bpmMax !== undefined) {
+    where.bpm = {};
+    if (bpmMin !== undefined) where.bpm.gte = bpmMin;
+    if (bpmMax !== undefined) where.bpm.lte = bpmMax;
+  }
+
+  if (key) {
+    where.key = key;
+  }
+
+  if (isExplicit !== undefined) {
+    where.isExplicit = isExplicit;
+  }
+
+  if (releaseDateStart || releaseDateEnd) {
+    where.releaseDate = {};
+    if (releaseDateStart) where.releaseDate.gte = releaseDateStart;
+    if (releaseDateEnd) where.releaseDate.lte = releaseDateEnd;
+  }
+
+  // Execute the query
+  const tracks = await prisma.track.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    skip: offset,
+    take: limit,
+    include: {
+      user: {
+        select: {
+          id: true,
+          username: true,
+        },
+      },
+    },
+  });
+
+  const total = await prisma.track.count({ where });
+
+  return { tracks, total };
+}
+
+/**
+ * Filter tracks using raw SQL for full-text search combined with array filtering
+ * This approach is more efficient for complex filters and full-text search
+ */
+export async function searchTracks(options: TrackFilterOptions) {
+  const {
+    searchTerm,
+    genres,
+    moods,
+    artists,
+    tags,
+    bpmMin,
+    bpmMax,
+    limit = 20,
+    offset = 0,
+  } = options;
+
+  // Build the SQL query parts
+  const conditions: string[] = ["status = 'ACTIVE'"];
+  const params: any[] = [];
+  let paramIndex = 1;
+
+  // Add full-text search condition if searchTerm is provided
+  if (searchTerm) {
+    conditions.push(`search_vector @@ to_tsquery('english', $${paramIndex})`);
+    params.push(searchTerm.split(" ").join(" & "));
+    paramIndex++;
+  }
+
+  // Add array filters
+  if (genres && genres.length > 0) {
+    conditions.push(`genre_names && $${paramIndex}`);
+    params.push(genres);
+    paramIndex++;
+  }
+
+  if (moods && moods.length > 0) {
+    conditions.push(`mood_names && $${paramIndex}`);
+    params.push(moods);
+    paramIndex++;
+  }
+
+  if (artists && artists.length > 0) {
+    conditions.push(`artist_names && $${paramIndex}`);
+    params.push(artists);
+    paramIndex++;
+  }
+
+  if (tags && tags.length > 0) {
+    conditions.push(`tag_names && $${paramIndex}`);
+    params.push(tags);
+    paramIndex++;
+  }
+
+  // Add numeric range filters
+  if (bpmMin !== undefined) {
+    conditions.push(`bpm >= $${paramIndex}`);
+    params.push(bpmMin);
+    paramIndex++;
+  }
+
+  if (bpmMax !== undefined) {
+    conditions.push(`bpm <= $${paramIndex}`);
+    params.push(bpmMax);
+    paramIndex++;
+  }
+
+  // Build the WHERE clause
+  const whereClause =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  // Build the ORDER BY clause
+  let orderByClause = "ORDER BY created_at DESC";
+  if (searchTerm) {
+    orderByClause = `ORDER BY ts_rank(search_vector, to_tsquery('english', $1)) DESC, created_at DESC`;
+  }
+
+  // Build the complete query
+  const query = `
+    SELECT 
+      id, title, artist, duration, cover_art, is_public, 
+      user_id, created_at, updated_at, bpm, key, 
+      genre_names, mood_names, artist_names, tag_names
+    FROM tracks
+    ${whereClause}
+    ${orderByClause}
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
+  `;
+
+  // Add limit and offset params
+  params.push(limit, offset);
+
+  // Execute the query
+  const tracks = await prisma.$queryRawUnsafe(query, ...params);
+
+  // Count total results
+  const countQuery = `
+    SELECT COUNT(*) as total
+    FROM tracks
+    ${whereClause}
+  `;
+
+  const [{ total }] = await prisma.$queryRawUnsafe<Array<{ total: number }>>(
+    countQuery,
+    ...params.slice(0, params.length - 2)
+  );
+
+  return { tracks, total };
+}
+
+/**
+ * Get available filter options (genres, moods, etc.)
+ * This helps populate filter UI components
+ */
+export async function getFilterOptions() {
+  const [genres, moods, tags] = await Promise.all([
+    prisma.genre.findMany({ orderBy: { name: "asc" } }),
+    prisma.mood.findMany({ orderBy: { name: "asc" } }),
+    prisma.tag.findMany({ orderBy: { name: "asc" } }),
+  ]);
+
+  // Get the most common artists (limited to top 100)
+  const topArtists = await prisma.$queryRaw<{ name: string; count: number }[]>`
+    SELECT name, COUNT(*) as count
+    FROM artists a
+    JOIN track_credits tc ON a.id = tc.artist_id
+    GROUP BY name
+    ORDER BY count DESC
+    LIMIT 100
+  `;
+
+  return {
+    genres: genres.map((g) => g.name),
+    moods: moods.map((m) => m.name),
+    tags: tags.map((t) => t.name),
+    artists: topArtists.map((a) => a.name),
+  };
+}
+
+/**
+ * Example usage
+ */
+async function example() {
+  // Simple filtering with Prisma
+  const technoTracks = await filterTracks({
+    genres: ["Techno"],
+    bpmMin: 120,
+    bpmMax: 140,
+    limit: 10,
+  });
+
+  console.log(`Found ${technoTracks.total} techno tracks`);
+
+  // Full-text search with raw SQL
+  const searchResults = await searchTracks({
+    searchTerm: "electronic dance",
+    genres: ["House"],
+    limit: 10,
+  });
+
+  console.log(`Found ${searchResults.total} tracks matching search`);
+
+  // Get filter options for UI
+  const filterOptions = await getFilterOptions();
+  console.log(`Available genres: ${filterOptions.genres.join(", ")}`);
+}
+
+// Uncomment to run the example
+// example()
+//   .catch(console.error)
+//   .finally(() => prisma.$disconnect());

--- a/packages/core-storage/types/examples/track-filtering.d.ts
+++ b/packages/core-storage/types/examples/track-filtering.d.ts
@@ -1,0 +1,103 @@
+/**
+ * Example functions for filtering tracks using denormalized arrays
+ */
+interface TrackFilterOptions {
+    searchTerm?: string;
+    genres?: string[];
+    moods?: string[];
+    artists?: string[];
+    tags?: string[];
+    bpmMin?: number;
+    bpmMax?: number;
+    key?: string;
+    isExplicit?: boolean;
+    releaseDateStart?: Date;
+    releaseDateEnd?: Date;
+    limit?: number;
+    offset?: number;
+}
+/**
+ * Filter tracks using Prisma's query API
+ * This approach works well for simple filters
+ */
+export declare function filterTracks(options: TrackFilterOptions): Promise<{
+    tracks: ({
+        user: {
+            id: string;
+            username: string;
+        };
+    } & {
+        status: import(".prisma/client").$Enums.TrackStatus;
+        id: string;
+        waveformData: number[];
+        duration: number | null;
+        wavConversionStatus: import(".prisma/client").$Enums.AudioFileConversionStatus;
+        flacConversionStatus: import(".prisma/client").$Enums.AudioFileConversionStatus;
+        wavCreatedAt: Date | null;
+        wavLastRequestedAt: Date | null;
+        flacCreatedAt: Date | null;
+        flacLastRequestedAt: Date | null;
+        createdAt: Date;
+        updatedAt: Date;
+        title: string;
+        primaryArtistId: string;
+        primaryArtistName: string | null;
+        originalFormat: import(".prisma/client").$Enums.SourceFormat;
+        originalUrl: string;
+        fullTrackWavUrl: string | null;
+        fullTrackMp3Url: string | null;
+        fullTrackFlacUrl: string | null;
+        coverArt: string | null;
+        metadata: import(".prisma/client/runtime/library").JsonValue | null;
+        isPublic: boolean;
+        userId: string;
+        bpm: number | null;
+        key: string | null;
+        isrc: string | null;
+        language: string | null;
+        isExplicit: boolean;
+        releaseDate: Date | null;
+        releaseDatePrecision: import(".prisma/client").$Enums.DatePrecision | null;
+        originalReleaseDate: Date | null;
+        originalReleaseDatePrecision: import(".prisma/client").$Enums.DatePrecision | null;
+        catalogNumber: string | null;
+        copyright: string | null;
+        pLine: string | null;
+        cLine: string | null;
+        lyrics: string | null;
+        description: string | null;
+        version: string | null;
+        remixedBy: string | null;
+        replayGain: number | null;
+        peakAmplitude: number | null;
+        encodingTechnology: string | null;
+        recordingLocation: string | null;
+        recordLabelId: string | null;
+        licenseId: string | null;
+        genreNames: string[];
+        artistNames: string[];
+        moodNames: string[];
+        tagNames: string[];
+        searchConfigHash: string | null;
+    })[];
+    total: number;
+}>;
+/**
+ * Filter tracks using raw SQL for full-text search combined with array filtering
+ * This approach is more efficient for complex filters and full-text search
+ */
+export declare function searchTracks(options: TrackFilterOptions): Promise<{
+    tracks: unknown;
+    total: number;
+}>;
+/**
+ * Get available filter options (genres, moods, etc.)
+ * This helps populate filter UI components
+ */
+export declare function getFilterOptions(): Promise<{
+    genres: string[];
+    moods: string[];
+    tags: string[];
+    artists: string[];
+}>;
+export {};

--- a/packages/frontend/src/components/track-details/TrackHeader.tsx
+++ b/packages/frontend/src/components/track-details/TrackHeader.tsx
@@ -3,7 +3,7 @@ import { formatDuration } from "@/utils/formatDuration";
 
 interface TrackHeaderProps {
   title: string;
-  artist: string;
+  artistName: string | null;
   coverArt?: string | null;
   trackId: string;
   duration?: number | null;
@@ -11,7 +11,7 @@ interface TrackHeaderProps {
 
 export function TrackHeader({
   title,
-  artist,
+  artistName,
   coverArt,
   trackId,
   duration,
@@ -31,7 +31,7 @@ export function TrackHeader({
             {formatDuration(duration)}
           </span>
         </div>
-        <p className="text-gray-600">{artist}</p>
+        <p className="text-gray-600">{artistName}</p>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/track-list/TrackList.tsx
+++ b/packages/frontend/src/components/track-list/TrackList.tsx
@@ -20,7 +20,7 @@ import {
 interface SortOption {
   label: string;
   value: string;
-  field: "createdAt" | "title" | "duration" | "artist";
+  field: "createdAt" | "title" | "duration" | "primaryArtistName";
   direction: "asc" | "desc";
 }
 
@@ -54,13 +54,13 @@ const sortOptions: SortOption[] = [
   {
     label: "Artist A-Z",
     value: "artistAsc",
-    field: "artist",
+    field: "primaryArtistName",
     direction: "asc",
   },
   {
     label: "Artist Z-A",
     value: "artistDesc",
-    field: "artist",
+    field: "primaryArtistName",
     direction: "desc",
   },
 ];
@@ -293,7 +293,9 @@ export function TrackList({
                         {formatDuration(track.duration)}
                       </span>
                     </div>
-                    <p className="text-sm text-gray-600">{track.artist}</p>
+                    <p className="text-sm text-gray-600">
+                      {track.primaryArtistName}
+                    </p>
                     <p className="text-xs text-gray-500">
                       by {track.user.username}
                     </p>

--- a/packages/frontend/src/hooks/useInfiniteTracks.ts
+++ b/packages/frontend/src/hooks/useInfiniteTracks.ts
@@ -3,7 +3,7 @@ import { Track, PaginatedResponse } from "@/types";
 import { useAuthToken } from "./useAuthToken";
 import { apiRequest } from "@/api/client";
 
-type SortField = "createdAt" | "title" | "duration" | "artist";
+type SortField = "createdAt" | "title" | "duration" | "primaryArtistName";
 type SortDirection = "asc" | "desc";
 
 type UseInfiniteTracksOptions = {

--- a/packages/frontend/src/hooks/useTrackSort.ts
+++ b/packages/frontend/src/hooks/useTrackSort.ts
@@ -1,6 +1,10 @@
 import { useState } from "react";
 
-export type SortField = "createdAt" | "title" | "duration" | "artist";
+export type SortField =
+  | "createdAt"
+  | "title"
+  | "duration"
+  | "primaryArtistName";
 export type SortDirection = "asc" | "desc";
 
 export interface SortOption {
@@ -45,13 +49,13 @@ const defaultSortOptions: SortOption[] = [
   {
     label: "Artist A-Z",
     value: "artistAsc",
-    field: "artist",
+    field: "primaryArtistName",
     direction: "asc",
   },
   {
     label: "Artist Z-A",
     value: "artistDesc",
-    field: "artist",
+    field: "primaryArtistName",
     direction: "desc",
   },
 ];

--- a/packages/frontend/src/pages/BulkUploadTrack/hooks/useFileProcessing.ts
+++ b/packages/frontend/src/pages/BulkUploadTrack/hooks/useFileProcessing.ts
@@ -5,7 +5,7 @@ import { processFiles } from "../utils/fileMatching";
 
 export function useFileProcessing(getToken: () => string | null) {
   const [state, setState] = useState<BulkUploadState>({
-    defaultArtist: "",
+    defaultArtistName: "",
     matches: [],
     currentUploadIndex: -1,
     uploadedTracks: [],
@@ -140,7 +140,8 @@ export function useFileProcessing(getToken: () => string | null) {
           "data",
           JSON.stringify({
             title: match.title,
-            artist: state.defaultArtist.trim() || "Unknown Artist",
+            primaryArtistName:
+              state.defaultArtistName.trim() || "Unknown Artist",
             originalFormat,
           })
         );
@@ -170,11 +171,11 @@ export function useFileProcessing(getToken: () => string | null) {
         throw error;
       }
     }
-  }, [state.matches, state.defaultArtist, getToken]);
+  }, [state.matches, state.defaultArtistName, getToken]);
 
   const handleClearAll = useCallback(() => {
     setState({
-      defaultArtist: "",
+      defaultArtistName: "",
       matches: [],
       currentUploadIndex: -1,
       uploadedTracks: [],
@@ -203,7 +204,7 @@ export function useFileProcessing(getToken: () => string | null) {
       handleClearAll,
       removeUnmatchedArt,
       setDefaultArtist: (value: string) =>
-        setState((prev) => ({ ...prev, defaultArtist: value })),
+        setState((prev) => ({ ...prev, defaultArtistName: value })),
     },
   };
 }

--- a/packages/frontend/src/pages/BulkUploadTrack/index.tsx
+++ b/packages/frontend/src/pages/BulkUploadTrack/index.tsx
@@ -59,10 +59,10 @@ export function BulkUploadTrack() {
         />
 
         <FormInput
-          id="defaultArtist"
+          id="defaultArtistName"
           type="text"
           label="Default Artist (optional)"
-          value={state.defaultArtist}
+          value={state.defaultArtistName}
           onChange={(e) => setDefaultArtist(e.target.value)}
           disabled={isUploadInProgress}
         />

--- a/packages/frontend/src/pages/BulkUploadTrack/utils/types.ts
+++ b/packages/frontend/src/pages/BulkUploadTrack/utils/types.ts
@@ -7,7 +7,7 @@ export interface FileMatch {
 }
 
 export interface BulkUploadState {
-  defaultArtist: string;
+  defaultArtistName: string;
   matches: FileMatch[];
   currentUploadIndex: number;
   uploadedTracks: string[];

--- a/packages/frontend/src/pages/TrackDetails/index.tsx
+++ b/packages/frontend/src/pages/TrackDetails/index.tsx
@@ -51,7 +51,7 @@ export function TrackDetails() {
       <div>
         <TrackHeader
           title={track.title}
-          artist={track.artist}
+          artistName={track.primaryArtistName}
           coverArt={track.coverArt}
           trackId={track.id}
           duration={track.duration}

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -6,7 +6,7 @@ import { api } from "@/api/client";
 
 interface UploadFormData {
   title: string;
-  artist: string;
+  primaryArtistName: string;
   originalFormat: string | null;
   original: File | null;
   coverArt: File | null;
@@ -20,7 +20,7 @@ export function UploadTrack() {
     useForm<UploadFormData>({
       initialValues: {
         title: "",
-        artist: "",
+        primaryArtistName: "",
         originalFormat: null,
         original: null,
         coverArt: null,
@@ -35,7 +35,7 @@ export function UploadTrack() {
           "data",
           JSON.stringify({
             title: values.title,
-            artist: values.artist,
+            primaryArtistName: values.primaryArtistName,
             originalFormat: values.originalFormat,
           })
         );
@@ -84,12 +84,12 @@ export function UploadTrack() {
           />
 
           <FormInput
-            id="artist"
+            id="primaryArtistName"
             type="text"
             label="Artist"
             required
-            value={values.artist}
-            onChange={(e) => handleChange("artist", e.target.value)}
+            value={values.primaryArtistName}
+            onChange={(e) => handleChange("primaryArtistName", e.target.value)}
           />
 
           <FormInput

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -10,7 +10,7 @@ export interface User {
 export interface Track {
   id: string;
   title: string;
-  artist: string;
+  primaryArtistName: string | null;
   coverArt: string | null;
   originalUrl: string | null;
   fullTrackWavUrl: string | null;


### PR DESCRIPTION
This PR focuses on implementing the primary artist relationship while laying the groundwork for future metadata enhancements through schema preparations.

Actively Implemented Changes:
- Replaced string-based artist field with proper database relationships:
  - Added primary_artist_id and primary_artist_name columns to tracks table
  - Created foreign key constraints and indexes
  - Added triggers to maintain primary_artist_name consistency
  - Migrated existing artist string data to new structure
- Updated application to use new artist relationship:
  - Modified frontend components (TrackHeader, TrackList, TrackDetails)
  - Updated sorting and filtering to use primaryArtistName
  - Adapted bulk upload and track upload forms
  - Added array-based filtering for artists

Schema Preparation (Not Yet Implemented):
The following models and fields have been added to the schema but are not yet active in the application:
- New relationship models:
  - RecordLabel
  - Genre and TrackGenre
  - Album
  - CreditType and TrackCredit
  - Mood and TrackMood
  - Tag and TrackTag
  - License
- Extended Track model fields:
  - Musical information (bpm, key)
  - Release information (release date, catalog number)
  - Rights management (isrc, copyright, pLine, cLine)
  - Additional metadata (lyrics, description, version)

Infrastructure Improvements:
- Added PostgreSQL full-text search capabilities
- Implemented denormalized arrays for future many-to-many filtering
- Added pg_trgm extension support
- Created maintenance functions for search vectors

This PR completes the transition to a proper artist relationship model while preparing the database schema for future metadata enhancements. Only the artist-related changes are currently implemented in the application code; other schema additions serve as groundwork for upcoming features.