### PR TITLE
Split header dropdown into separate trigger and menu components

### DIFF
--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -49,6 +49,7 @@ function Header() {
       className={`bg-primary-600 text-white relative z-10 ${
         openDropdownId ? "sticky top-0" : ""
       }`}
+      onMouseDown={(e) => e.stopPropagation()}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="h-16 flex items-center justify-between gap-4">

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -2,7 +2,8 @@ import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { NotificationBell } from "./NotificationBell";
 import {
-  HeaderDropdown,
+  HeaderDropdownTrigger,
+  HeaderDropdownMenu,
   HeaderDropdownItem,
 } from "@/components/ui/HeaderDropdown";
 import {
@@ -71,7 +72,7 @@ function Header() {
               </div>
               <div className="flex items-center gap-2">
                 <NotificationBell />
-                <HeaderDropdown
+                <HeaderDropdownTrigger
                   id="user-menu"
                   trigger={
                     <button className="flex items-center gap-1 hover:text-primary-200">
@@ -92,7 +93,8 @@ function Header() {
                       </svg>
                     </button>
                   }
-                >
+                />
+                <HeaderDropdownMenu id="user-menu">
                   {isAdmin && (
                     <HeaderDropdownItem>
                       <Link to="/admin" className="block">
@@ -103,9 +105,9 @@ function Header() {
                   <HeaderDropdownItem onClick={logout}>
                     Logout
                   </HeaderDropdownItem>
-                </HeaderDropdown>
+                </HeaderDropdownMenu>
               </div>
-              <HeaderDropdown
+              <HeaderDropdownTrigger
                 id="mobile-menu"
                 trigger={
                   <button className="sm:hidden inline-flex items-center justify-center p-2 rounded-md hover:bg-primary-700 focus:outline-none">
@@ -127,9 +129,10 @@ function Header() {
                   </button>
                 }
                 mobileOnly
-              >
+              />
+              <HeaderDropdownMenu id="mobile-menu">
                 {navItems}
-              </HeaderDropdown>
+              </HeaderDropdownMenu>
             </div>
           ) : (
             !isLoginPage && (

--- a/packages/frontend/src/components/ui/HeaderDropdown.tsx
+++ b/packages/frontend/src/components/ui/HeaderDropdown.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from "react";
 import { useHeaderDropdown } from "@/contexts/HeaderDropdownContext";
+import { cn } from "@/utils/cn";
 
 interface HeaderDropdownProps {
   id: string;
@@ -52,15 +53,15 @@ export function HeaderDropdown({
            - Formula: max(1rem, (viewport - header-max-width) / 2 + padding)
       */}
       <div
-        className={`${
+        className={cn(
+          "fixed top-16 min-w-[200px] bg-primary-800 shadow-lg border border-primary-700 rounded-b-lg transition-all duration-200 ease-out",
           isOpen
-            ? "opacity-100 pointer-events-auto"
-            : "opacity-0 pointer-events-none"
-        } fixed ${
+            ? "opacity-100 pointer-events-auto visible"
+            : "opacity-0 pointer-events-none invisible",
           align === "right"
             ? "right-4 sm:right-6 lg:right-8"
             : "left-4 sm:left-6 lg:left-8"
-        } top-16 min-w-[200px] bg-primary-800 shadow-lg border border-primary-700 rounded-b-lg transition-opacity duration-200 ease-out`}
+        )}
         style={{
           maxWidth: "calc(100vw - 2rem)",
           [align === "right" ? "right" : "left"]:

--- a/packages/frontend/src/components/ui/HeaderDropdown.tsx
+++ b/packages/frontend/src/components/ui/HeaderDropdown.tsx
@@ -2,23 +2,23 @@ import { useRef, useEffect } from "react";
 import { useHeaderDropdown } from "@/contexts/HeaderDropdownContext";
 import { cn } from "@/utils/cn";
 
-interface HeaderDropdownProps {
+interface HeaderDropdownTriggerProps {
   id: string;
   trigger: React.ReactNode;
-  children: React.ReactNode;
-  align?: "left" | "right";
   mobileOnly?: boolean;
-  onOpenChange?: (isOpen: boolean) => void;
 }
 
-export function HeaderDropdown({
+interface HeaderDropdownMenuProps {
+  id: string;
+  children: React.ReactNode;
+  align?: "left" | "right";
+}
+
+export function HeaderDropdownTrigger({
   id,
   trigger,
-  children,
-  align = "right",
   mobileOnly = false,
-  onOpenChange,
-}: HeaderDropdownProps) {
+}: HeaderDropdownTriggerProps) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { openDropdownId, setOpenDropdownId, registerDropdownRef } =
     useHeaderDropdown();
@@ -32,10 +32,6 @@ export function HeaderDropdown({
     };
   }, [id, mobileOnly, registerDropdownRef]);
 
-  useEffect(() => {
-    onOpenChange?.(isOpen);
-  }, [isOpen, onOpenChange]);
-
   const handleToggle = () => {
     const newIsOpen = !isOpen;
     setOpenDropdownId(newIsOpen ? id : null);
@@ -44,32 +40,35 @@ export function HeaderDropdown({
   return (
     <div className="relative" ref={dropdownRef}>
       <div onClick={handleToggle}>{trigger}</div>
-      {/* 
-        Dropdown positioning:
-        1. Responsive padding matches header container: right-4 sm:right-6 lg:right-8
-        2. Dynamic position calculation ensures dropdown aligns with the max-w-7xl (80rem) header container:
-           - On smaller screens: stays 1rem from the edge
-           - On larger screens: aligns with header's max-width container edge
-           - Formula: max(1rem, (viewport - header-max-width) / 2 + padding)
-      */}
-      <div
-        className={cn(
-          "fixed top-16 min-w-[200px] bg-primary-800 shadow-lg border border-primary-700 rounded-b-lg transition-all duration-200 ease-out",
-          isOpen
-            ? "opacity-100 pointer-events-auto visible"
-            : "opacity-0 pointer-events-none invisible",
-          align === "right"
-            ? "right-4 sm:right-6 lg:right-8"
-            : "left-4 sm:left-6 lg:left-8"
-        )}
-        style={{
-          maxWidth: "calc(100vw - 2rem)",
-          [align === "right" ? "right" : "left"]:
-            "max(1rem, calc((100vw - 80rem) / 2 + 2rem))",
-        }}
-      >
-        {children}
-      </div>
+    </div>
+  );
+}
+
+export function HeaderDropdownMenu({
+  id,
+  children,
+  align = "right",
+}: HeaderDropdownMenuProps) {
+  const { openDropdownId } = useHeaderDropdown();
+  const isOpen = openDropdownId === id;
+
+  return (
+    <div
+      className={cn(
+        "absolute min-w-[200px] bg-primary-800 shadow-lg border border-primary-700 rounded-b-lg",
+        "top-full mt-1",
+        "transition-[opacity,visibility] duration-200 ease-out",
+        isOpen
+          ? "opacity-100 pointer-events-auto visible"
+          : "opacity-0 pointer-events-none invisible"
+      )}
+      style={{
+        maxWidth: "calc(100vw - 2rem)",
+        [align === "right" ? "right" : "left"]:
+          "max(1rem, calc((100vw - 80rem) / 2 + 2rem))",
+      }}
+    >
+      {children}
     </div>
   );
 }
@@ -83,10 +82,23 @@ export function HeaderDropdownItem({
   onClick?: () => void;
   className?: string;
 }) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onClick?.();
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
   return (
     <div
-      onClick={onClick}
-      className={`px-6 py-3 text-sm transition-colors duration-150 whitespace-nowrap block hover:bg-primary-700/50 cursor-pointer ${className}`}
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      className={cn(
+        "px-6 py-3 text-sm transition-colors duration-150 whitespace-nowrap block hover:bg-primary-700/50 cursor-pointer",
+        className
+      )}
     >
       {children}
     </div>

--- a/packages/frontend/src/components/ui/HeaderDropdown.tsx
+++ b/packages/frontend/src/components/ui/HeaderDropdown.tsx
@@ -64,6 +64,11 @@ export function HeaderDropdownMenu({
       )}
       style={{
         maxWidth: "calc(100vw - 2rem)",
+        // Aligns the dropdown with the header's max-width container (80rem):
+        // - On smaller screens (<82rem), keeps dropdown 1rem from screen edge
+        // - On larger screens, aligns with the header's content by calculating
+        //   the space between viewport edge and header container (100vw - 80rem)/2,
+        //   then adding 2rem to match header's padding
         [align === "right" ? "right" : "left"]:
           "max(1rem, calc((100vw - 80rem) / 2 + 2rem))",
       }}

--- a/packages/frontend/src/components/ui/HeaderDropdown.tsx
+++ b/packages/frontend/src/components/ui/HeaderDropdown.tsx
@@ -56,7 +56,7 @@ export function HeaderDropdownMenu({
     <div
       className={cn(
         "absolute min-w-[200px] bg-primary-800 shadow-lg border border-primary-700 rounded-b-lg",
-        "top-full mt-1",
+        "top-[calc(100%-1px)]",
         "transition-[opacity,visibility] duration-200 ease-out",
         isOpen
           ? "opacity-100 pointer-events-auto visible"
@@ -82,19 +82,9 @@ export function HeaderDropdownItem({
   onClick?: () => void;
   className?: string;
 }) {
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onClick?.();
-  };
-
-  const handleMouseDown = (e: React.MouseEvent) => {
-    e.stopPropagation();
-  };
-
   return (
     <div
-      onClick={handleClick}
-      onMouseDown={handleMouseDown}
+      onClick={onClick}
       className={cn(
         "px-6 py-3 text-sm transition-colors duration-150 whitespace-nowrap block hover:bg-primary-700/50 cursor-pointer",
         className

--- a/packages/frontend/src/contexts/HeaderDropdownContext.tsx
+++ b/packages/frontend/src/contexts/HeaderDropdownContext.tsx
@@ -44,14 +44,7 @@ export function HeaderDropdownProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (!openDropdownId) return;
-
-      const activeDropdown = dropdownRefs.current.get(openDropdownId);
-      if (
-        activeDropdown?.ref &&
-        !activeDropdown.ref.contains(event.target as Node)
-      ) {
-        setOpenDropdownId(null);
-      }
+      setOpenDropdownId(null);
     }
 
     // Throttle resize handler to run at most once every 150ms


### PR DESCRIPTION
This PR refactors the header dropdown component architecture to improve maintainability and fix event handling issues:

- Split `HeaderDropdown` into separate `HeaderDropdownTrigger` and `HeaderDropdownMenu` components
- Fix event propagation in header by adding `stopPropagation` to prevent unwanted dropdown closures
- Improve notification loading by moving logic to `useEffect` based on dropdown open state
- Enhance dropdown positioning and transition styles
- Clean up click outside handling logic in `HeaderDropdownContext`