### PR TITLE
Add track licensing system

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
     "db:setup": "cd packages/core-storage && pnpm prisma migrate dev && pnpm prisma generate",
-    "db:bootstrap": "pnpm --filter @wavtopia/core-storage bootstrap"
+    "db:bootstrap": "pnpm --filter @wavtopia/core-storage bootstrap",
+    "db:seed": "pnpm --filter @wavtopia/core-storage db:seed"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -10,6 +10,7 @@ import { initializeStorage } from "./services/storage";
 import { config } from "./config";
 import adminRoutes from "./routes/admin";
 import { notificationRoutes } from "./routes/notifications";
+import licenseRoutes from "./routes/licenses";
 
 const app = express();
 
@@ -27,7 +28,10 @@ app.use("/api/auth", authRoutes);
 app.use("/api/track", trackRoutes);
 app.use("/api/tracks", tracksRoutes);
 app.use("/api/admin", adminRoutes);
+// TODO: notifications can go under /api/user
 app.use("/api/notifications", notificationRoutes);
+// TODO: licenses can go under /api/settings
+app.use("/api/licenses", licenseRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/packages/backend/src/routes/licenses.ts
+++ b/packages/backend/src/routes/licenses.ts
@@ -1,24 +1,46 @@
 import { Router } from "express";
 import { prisma } from "../lib/prisma";
 import { authenticate } from "../middleware/auth";
+import { LicenseType } from "@wavtopia/core-storage";
 
 const router = Router();
+
+// Then sort them in our preferred order
+const TYPE_ORDER: Record<LicenseType, number> = {
+  [LicenseType.CC_BY_NC_SA]: 1,
+  [LicenseType.CC_BY_SA]: 2,
+  [LicenseType.CC_BY_NC]: 3,
+  [LicenseType.CC_BY]: 4,
+  [LicenseType.CC_BY_ND]: 7,
+  [LicenseType.CC_BY_NC_ND]: 8,
+  [LicenseType.ALL_RIGHTS_RESERVED]: 5,
+  [LicenseType.CUSTOM]: 6,
+};
 
 /**
  * Get all enabled licenses
  * GET /licenses
+ *
+ * Orders licenses to encourage collaborative sharing:
+ * 1. CC BY-NC-SA (recommended for most users)
+ * 2. CC BY-SA (for those okay with commercial use)
+ * 3. CC BY-NC (for non-commercial without share requirement)
+ * 4. CC BY (most permissive)
+ * 5. All Rights Reserved (least collaborative)
  */
 router.get("/", authenticate, async (req, res) => {
+  // First get all enabled licenses
   const licenses = await prisma.license.findMany({
     where: {
       enabled: true,
     },
-    orderBy: {
-      type: "asc",
-    },
   });
 
-  res.json(licenses);
+  const sortedLicenses = licenses.sort(
+    (a, b) => TYPE_ORDER[a.type] - TYPE_ORDER[b.type]
+  );
+
+  res.json(sortedLicenses);
 });
 
 export default router;

--- a/packages/backend/src/routes/licenses.ts
+++ b/packages/backend/src/routes/licenses.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import { prisma } from "../lib/prisma";
+import { authenticate } from "../middleware/auth";
+
+const router = Router();
+
+/**
+ * Get all enabled licenses
+ * GET /licenses
+ */
+router.get("/", authenticate, async (req, res) => {
+  const licenses = await prisma.license.findMany({
+    where: {
+      enabled: true,
+    },
+    orderBy: {
+      type: "asc",
+    },
+  });
+
+  res.json(licenses);
+});
+
+export default router;

--- a/packages/backend/src/routes/track/core.ts
+++ b/packages/backend/src/routes/track/core.ts
@@ -34,12 +34,14 @@ export const trackSchema = z.object({
   key: z.string().optional(),
   isExplicit: z.boolean().optional(),
   // Release Information
-  releaseDate: z.string().optional(),
+  releaseDate: z.string().datetime().optional(),
   releaseDatePrecision: z.nativeEnum(DatePrecision).optional(),
   // Metadata
   description: z.string().optional(),
   // Classification/Taxonomy
-  genres: z.array(z.string()).optional(),
+  genres: z.array(z.string()),
+  // License
+  licenseId: z.string().uuid("License ID must be a valid UUID"),
 });
 
 // Get single track
@@ -203,6 +205,7 @@ router.post("/", authenticate, uploadTrackFiles, async (req, res, next) => {
           key: data.key,
           isExplicit: data.isExplicit,
           description: data.description,
+          licenseId: data.licenseId,
           ...(data.releaseDate && data.releaseDatePrecision
             ? {
                 releaseDate: new Date(data.releaseDate),

--- a/packages/backend/src/routes/track/media.ts
+++ b/packages/backend/src/routes/track/media.ts
@@ -36,6 +36,13 @@ router.get(
       // Stream the file directly from MinIO
       const fileStream = await getObject(track.coverArt);
       res.setHeader("Content-Type", contentType);
+      // Set cache control headers
+      // Cache expiry set to 2 minutes, for testing. TODO: Increase expiry time
+      res.setHeader("Cache-Control", "public, max-age=120");
+      res.setHeader(
+        "Expires",
+        new Date(Date.now() + 2 * 60 * 1000).toUTCString()
+      );
       fileStream.pipe(res);
     } catch (error) {
       next(error);
@@ -204,6 +211,13 @@ router.get(
       res.setHeader(
         "Content-Disposition",
         `attachment; filename="${track.title}.${track.originalFormat}"`
+      );
+      // Set cache control headers
+      // Cache expiry set to 2 minutes, for testing. TODO: Increase expiry time
+      res.setHeader("Cache-Control", "public, max-age=120");
+      res.setHeader(
+        "Expires",
+        new Date(Date.now() + 2 * 60 * 1000).toUTCString()
       );
       fileStream.pipe(res);
     } catch (error) {

--- a/packages/core-storage/package.json
+++ b/packages/core-storage/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "main": "dist/index.js",
   "types": "types/index.d.ts",
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rimraf dist types",
@@ -13,7 +16,8 @@
     "migrate": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
     "postinstall": "pnpm generate",
-    "bootstrap": "ts-node src/cli/bootstrap-db.ts"
+    "bootstrap": "ts-node src/cli/bootstrap-db.ts",
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
     "@prisma/client": "5.22.0",

--- a/packages/core-storage/prisma/migrations/20250315011148_add_license_model_and_types/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250315011148_add_license_model_and_types/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `terms` on the `licenses` table. All the data in the column will be lost.
+  - Added the required column `type` to the `licenses` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "LicenseType" AS ENUM ('CC_BY', 'CC_BY_SA', 'CC_BY_NC', 'CC_BY_NC_SA', 'CC_BY_ND', 'CC_BY_NC_ND', 'ALL_RIGHTS_RESERVED', 'CUSTOM');
+
+-- DropIndex
+DROP INDEX "licenses_name_key";
+
+-- AlterTable
+ALTER TABLE "licenses" DROP COLUMN "terms",
+ADD COLUMN     "allows_commercial_use" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "allows_remixing" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "allows_sharing" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "allows_stem_separation" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "allows_stem_sharing" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "credit_format" TEXT,
+ADD COLUMN     "custom_terms" TEXT,
+ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "requires_attribution" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "requires_credit" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "royalty_terms" TEXT,
+ADD COLUMN     "territory_restrictions" TEXT,
+ADD COLUMN     "type" "LicenseType" NOT NULL,
+ADD COLUMN     "usage_restrictions" TEXT;

--- a/packages/core-storage/prisma/migrations/20250315013507_add_unique_license_name/migration.sql
+++ b/packages/core-storage/prisma/migrations/20250315013507_add_unique_license_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `licenses` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "licenses_name_key" ON "licenses"("name");

--- a/packages/core-storage/prisma/schema/track_extensions.prisma
+++ b/packages/core-storage/prisma/schema/track_extensions.prisma
@@ -182,7 +182,7 @@ enum LicenseType {
 // License - Legal terms for track usage
 model License {
   id                    String    @id @default(uuid())
-  name                  String
+  name                  String    @unique
   type                  LicenseType
   description           String?
   customTerms           String?                   @map("custom_terms")            // For custom license terms

--- a/packages/core-storage/prisma/schema/track_extensions.prisma
+++ b/packages/core-storage/prisma/schema/track_extensions.prisma
@@ -167,15 +167,41 @@ model TrackTag {
   @@map("track_tags")
 }
 
+// License types for track usage
+enum LicenseType {
+  CC_BY           // Attribution
+  CC_BY_SA        // Attribution-ShareAlike
+  CC_BY_NC        // Attribution-NonCommercial
+  CC_BY_NC_SA     // Attribution-NonCommercial-ShareAlike
+  CC_BY_ND        // Attribution-NoDerivs
+  CC_BY_NC_ND     // Attribution-NonCommercial-NoDerivs
+  ALL_RIGHTS_RESERVED
+  CUSTOM          // For custom licensing terms
+}
+
 // License - Legal terms for track usage
 model License {
-  id          String   @id @default(uuid())
-  name        String   @unique
-  description String?
-  terms       String?
-  tracks      Track[]
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
-  
+  id                    String    @id @default(uuid())
+  name                  String
+  type                  LicenseType
+  description           String?
+  customTerms           String?                   @map("custom_terms")            // For custom license terms
+  allowsRemixing        Boolean   @default(false) @map("allows_remixing")
+  allowsSharing         Boolean   @default(false) @map("allows_sharing")
+  requiresAttribution   Boolean   @default(true)  @map("requires_attribution")
+  allowsCommercialUse   Boolean   @default(false) @map("allows_commercial_use")
+  // Additional music-specific fields
+  allowsStemSeparation  Boolean   @default(false) @map("allows_stem_separation")
+  allowsStemSharing     Boolean   @default(false) @map("allows_stem_sharing")
+  requiresCredit        Boolean   @default(true)  @map("requires_credit")
+  creditFormat          String?                   @map("credit_format")           // Template for how credit should be given
+  territoryRestrictions String?                   @map("territory_restrictions")  // Comma-separated list of restricted territories
+  usageRestrictions     String?                   @map("usage_restrictions")      // Any specific usage restrictions
+  royaltyTerms          String?                   @map("royalty_terms")           // Terms for commercial usage if allowed
+  enabled               Boolean   @default(false) @map("enabled")                 // Whether this license is available for users to select
+  tracks                Track[]
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt      @map("updated_at")
+
   @@map("licenses")
-} 
+}

--- a/packages/core-storage/prisma/seed.ts
+++ b/packages/core-storage/prisma/seed.ts
@@ -1,11 +1,15 @@
 /// <reference types="node" />
 import { PrismaClient } from ".prisma/client";
+import { seedFeatureFlags } from "./seeds/feature-flags";
 import { seedLicenses } from "./seeds/licenses";
 
 const prisma = new PrismaClient();
 
 async function main() {
   console.log("Starting database seeding...");
+
+  // Seed feature flags
+  await seedFeatureFlags();
 
   // Seed licenses
   await seedLicenses();

--- a/packages/core-storage/prisma/seed.ts
+++ b/packages/core-storage/prisma/seed.ts
@@ -1,0 +1,27 @@
+/// <reference types="node" />
+import { PrismaClient } from ".prisma/client";
+import { seedLicenses } from "./seeds/licenses";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log("Starting database seeding...");
+
+  // Seed licenses
+  await seedLicenses();
+
+  // Add other seed functions here as needed
+  // await seedOtherData()
+
+  console.log("Database seeding completed.");
+}
+
+main()
+  .catch((e) => {
+    console.error("Error during database seeding:");
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/core-storage/prisma/seeds/feature-flags.ts
+++ b/packages/core-storage/prisma/seeds/feature-flags.ts
@@ -1,0 +1,39 @@
+/// <reference types="node" />
+import { PrismaClient } from ".prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function seedFeatureFlags() {
+  const flags = [
+    {
+      name: "EARLY_ACCESS_REQUIRED",
+      description: "Requires users to have an invite code to register",
+      isEnabled: true,
+    },
+    // Any other default feature flags would go here
+  ];
+
+  console.log("Seeding feature flags...");
+
+  for (const flag of flags) {
+    await prisma.featureFlag.upsert({
+      where: { name: flag.name },
+      update: flag,
+      create: flag,
+    });
+  }
+
+  console.log("Feature flag seeding completed.");
+}
+
+// Run if executed directly
+if (require.main === module) {
+  seedFeatureFlags()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/packages/core-storage/prisma/seeds/licenses.ts
+++ b/packages/core-storage/prisma/seeds/licenses.ts
@@ -162,20 +162,11 @@ export async function seedLicenses() {
   console.log("Seeding licenses...");
 
   for (const license of licenses) {
-    const existing = await prisma.license.findFirst({
+    await prisma.license.upsert({
       where: { name: license.name },
+      update: license,
+      create: license,
     });
-
-    if (existing) {
-      await prisma.license.update({
-        where: { id: existing.id },
-        data: license,
-      });
-    } else {
-      await prisma.license.create({
-        data: license,
-      });
-    }
   }
 
   console.log("License seeding completed.");

--- a/packages/core-storage/prisma/seeds/licenses.ts
+++ b/packages/core-storage/prisma/seeds/licenses.ts
@@ -1,0 +1,194 @@
+/// <reference types="node" />
+import { PrismaClient, LicenseType } from ".prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function seedLicenses() {
+  const licenses = [
+    // CC BY - Attribution
+    {
+      name: "Creative Commons Attribution 4.0",
+      type: LicenseType.CC_BY,
+      description:
+        "This license lets others distribute, remix, adapt, and build upon your work, even commercially, as long as they credit you for the original creation.",
+      allowsRemixing: true,
+      allowsSharing: true,
+      requiresAttribution: true,
+      allowsCommercialUse: true,
+      allowsStemSeparation: true,
+      allowsStemSharing: true,
+      requiresCredit: true,
+      creditFormat: 'Track "{title}" by {artist} is licensed under CC BY 4.0',
+      enabled: true,
+    },
+
+    // CC BY-SA - Attribution-ShareAlike
+    {
+      name: "Creative Commons Attribution-ShareAlike 4.0",
+      type: LicenseType.CC_BY_SA,
+      description:
+        "This license lets others remix, adapt, and build upon your work even for commercial purposes, as long as they credit you and license their new creations under identical terms.",
+      allowsRemixing: true,
+      allowsSharing: true,
+      requiresAttribution: true,
+      allowsCommercialUse: true,
+      allowsStemSeparation: true,
+      allowsStemSharing: true,
+      requiresCredit: true,
+      creditFormat:
+        'Track "{title}" by {artist} is licensed under CC BY-SA 4.0. Remix must be shared under the same license.',
+      enabled: false,
+    },
+
+    // CC BY-NC - Attribution-NonCommercial (Recommended for most users)
+    {
+      name: "Creative Commons Attribution-NonCommercial 4.0",
+      type: LicenseType.CC_BY_NC,
+      description:
+        "This license lets others remix, adapt, and build upon your work non-commercially with attribution.",
+      allowsRemixing: true,
+      allowsSharing: true,
+      requiresAttribution: true,
+      allowsCommercialUse: false,
+      allowsStemSeparation: true,
+      allowsStemSharing: true,
+      requiresCredit: true,
+      creditFormat:
+        'Track "{title}" by {artist} is licensed under CC BY-NC 4.0',
+      usageRestrictions:
+        "No commercial use permitted without explicit permission from the creator.",
+      enabled: true,
+    },
+
+    // CC BY-NC-SA - Attribution-NonCommercial-ShareAlike (Platform Default)
+    {
+      name: "Creative Commons Attribution-NonCommercial-ShareAlike 4.0",
+      type: LicenseType.CC_BY_NC_SA,
+      description:
+        "This license lets others remix, adapt, and build upon your work non-commercially, as long as they credit you and license their new creations under identical terms.",
+      allowsRemixing: true,
+      allowsSharing: true,
+      requiresAttribution: true,
+      allowsCommercialUse: false,
+      allowsStemSeparation: true,
+      allowsStemSharing: true,
+      requiresCredit: true,
+      creditFormat:
+        'Track "{title}" by {artist} is licensed under CC BY-NC-SA 4.0. Remix must be shared under the same license.',
+      usageRestrictions:
+        "No commercial use permitted. Derivative works must be shared under the same license.",
+      enabled: true,
+    },
+
+    // CC BY-ND - Attribution-NoDerivs
+    {
+      name: "Creative Commons Attribution-NoDerivs 4.0",
+      type: LicenseType.CC_BY_ND,
+      description:
+        "This license allows for redistribution, commercial and non-commercial, as long as it is passed along unchanged and in whole, with credit to you.",
+      allowsRemixing: false,
+      allowsSharing: true,
+      requiresAttribution: true,
+      allowsCommercialUse: true,
+      allowsStemSeparation: false,
+      allowsStemSharing: false,
+      requiresCredit: true,
+      creditFormat:
+        'Track "{title}" by {artist} is licensed under CC BY-ND 4.0',
+      usageRestrictions: "No modifications or derivative works permitted.",
+      enabled: false,
+    },
+
+    // CC BY-NC-ND - Attribution-NonCommercial-NoDerivs
+    {
+      name: "Creative Commons Attribution-NonCommercial-NoDerivs 4.0",
+      type: LicenseType.CC_BY_NC_ND,
+      description:
+        "This license is the most restrictive of the six main CC licenses, only allowing others to download your works and share them with others as long as they credit you, but they can't change them in any way or use them commercially.",
+      allowsRemixing: false,
+      allowsSharing: true,
+      requiresAttribution: true,
+      allowsCommercialUse: false,
+      allowsStemSeparation: false,
+      allowsStemSharing: false,
+      requiresCredit: true,
+      creditFormat:
+        'Track "{title}" by {artist} is licensed under CC BY-NC-ND 4.0',
+      usageRestrictions:
+        "No commercial use, modifications, or derivative works permitted.",
+      enabled: false,
+    },
+
+    // All Rights Reserved
+    {
+      name: "All Rights Reserved",
+      type: LicenseType.ALL_RIGHTS_RESERVED,
+      description:
+        "Traditional copyright. All rights are reserved and protected.",
+      allowsRemixing: false,
+      allowsSharing: false,
+      requiresAttribution: true,
+      allowsCommercialUse: false,
+      allowsStemSeparation: false,
+      allowsStemSharing: false,
+      requiresCredit: true,
+      usageRestrictions:
+        "All rights reserved. No use permitted without explicit permission from the creator.",
+      enabled: true,
+    },
+
+    // Custom - Stem Licensing
+    {
+      name: "Custom Stem License",
+      type: LicenseType.CUSTOM,
+      description:
+        "Custom license for stem sharing with specific terms for commercial usage.",
+      allowsRemixing: true,
+      allowsSharing: true,
+      requiresAttribution: true,
+      allowsCommercialUse: true,
+      allowsStemSeparation: true,
+      allowsStemSharing: true,
+      requiresCredit: true,
+      creditFormat: 'Contains stems from "{title}" by {artist}',
+      customTerms:
+        "Commercial use of stems requires explicit permission and may be subject to royalty payments.",
+      royaltyTerms:
+        "Commercial usage of stems requires a separate licensing agreement. Contact creator for details.",
+      enabled: false,
+    },
+  ];
+
+  console.log("Seeding licenses...");
+
+  for (const license of licenses) {
+    const existing = await prisma.license.findFirst({
+      where: { name: license.name },
+    });
+
+    if (existing) {
+      await prisma.license.update({
+        where: { id: existing.id },
+        data: license,
+      });
+    } else {
+      await prisma.license.create({
+        data: license,
+      });
+    }
+  }
+
+  console.log("License seeding completed.");
+}
+
+// Run the seed if this file is executed directly
+if (require.main === module) {
+  seedLicenses()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/packages/core-storage/src/cli/bootstrap-db.ts
+++ b/packages/core-storage/src/cli/bootstrap-db.ts
@@ -69,16 +69,6 @@ async function bootstrap(username: string, email: string, password: string) {
       email: user.email,
     });
 
-    // Create and enable EARLY_ACCESS_REQUIRED feature flag
-    const flag = await prisma.featureFlag.create({
-      data: {
-        name: "EARLY_ACCESS_REQUIRED",
-        description: "Requires users to have an invite code to register",
-        isEnabled: true,
-      },
-    });
-    console.log("Created and enabled feature flag:", flag.name);
-
     await prisma.$disconnect();
   } catch (error) {
     console.error("Error bootstrapping database:", error);

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -30,6 +30,8 @@ export {
   NotificationType,
   AudioFileConversionStatus,
   DatePrecision,
+  License,
+  LicenseType,
 } from ".prisma/client";
 
 export {

--- a/packages/core-storage/types/index.d.ts
+++ b/packages/core-storage/types/index.d.ts
@@ -2,6 +2,6 @@ export { DEFAULT_URL_EXPIRY_SECONDS, StorageService, type StorageFile, } from ".
 export { PrismaService } from "./services/prisma";
 export { deleteLocalFile, ensureDirectoryExists, normalizeFilePath, } from "./services/local-storage";
 export { config, type StorageConfig, type DatabaseConfig, type RedisConfig, type SharedConfig, } from "./config";
-export { Prisma, User, Role, SourceFormat, TrackStatus, InviteCode, FeatureFlag, Notification, NotificationType, AudioFileConversionStatus, DatePrecision, } from ".prisma/client";
+export { Prisma, User, Role, SourceFormat, TrackStatus, InviteCode, FeatureFlag, Notification, NotificationType, AudioFileConversionStatus, DatePrecision, License, LicenseType, } from ".prisma/client";
 export { type Track, type Stem, type TrackShare, type Genre, type PaginatedResponse, type PaginationParams, encodeCursor, decodeCursor, } from "./types";
 export * from "./auth";

--- a/packages/frontend/nginx.conf
+++ b/packages/frontend/nginx.conf
@@ -85,7 +85,21 @@ http {
             include /etc/nginx/proxy_params*;
         }
 
+        location ~ ^/api/track/[^/]+/original$ {
+            # TODO: Pass through the cache headers from the backend
+            add_header X-Debug-Location "track-original" always;
+            proxy_hide_header Cache-Control;
+            proxy_hide_header Expires;
+            proxy_hide_header Pragma;
+            # FIXME: Increase cache expiry time:
+            add_header Cache-Control "public, max-age=120" always;
+            expires 2m;
+            proxy_pass http://localhost:3002;
+            include /etc/nginx/proxy_params*;
+        }
+
         location ~ ^/api/track/[^/]+/cover$ {
+            # TODO: Pass through the cache headers from the backend
             add_header X-Debug-Location "track-cover" always;
             proxy_hide_header Cache-Control;
             proxy_hide_header Expires;

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -9,9 +9,18 @@ import {
   FormDateWithPrecision,
   DatePrecision,
 } from "@/components/ui/forms";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/Select";
 import { useForm } from "@/hooks/useForm";
 import { useAuthToken } from "@/hooks/useAuthToken";
 import { api } from "@/api/client";
+import { useQuery } from "@tanstack/react-query";
+import type { License } from "@wavtopia/core-storage";
 
 const GENRE_PLACEHOLDERS = [
   "Electronic, House, Techno",
@@ -56,11 +65,24 @@ interface UploadFormData {
   isExplicit: boolean;
   releaseDate: Date | undefined;
   releaseDatePrecision: DatePrecision;
+  licenseId: string | undefined;
 }
 
 export function UploadTrack() {
   const navigate = useNavigate();
   const { getToken } = useAuthToken();
+
+  const { data: licenses } = useQuery<License[]>({
+    queryKey: ["licenses"],
+    queryFn: async () => {
+      const response = await fetch("/api/licenses", {
+        headers: {
+          Authorization: `Bearer ${getToken()!}`,
+        },
+      });
+      return response.json();
+    },
+  });
 
   const { values, handleChange, handleSubmit, isSubmitting, submitError } =
     useForm<UploadFormData>({
@@ -77,10 +99,14 @@ export function UploadTrack() {
         isExplicit: false,
         releaseDate: undefined,
         releaseDatePrecision: "DAY",
+        licenseId: undefined,
       },
       onSubmit: async (values) => {
         if (!values.original) {
           throw new Error("Original track file is required");
+        }
+        if (!values.licenseId) {
+          throw new Error("License selection is required");
         }
 
         const formData = new FormData();
@@ -95,6 +121,7 @@ export function UploadTrack() {
             genres: values.genres,
             description: values.description,
             isExplicit: values.isExplicit,
+            licenseId: values.licenseId,
             ...(values.releaseDate && {
               releaseDate: values.releaseDate.toISOString(),
               releaseDatePrecision: values.releaseDatePrecision,
@@ -215,6 +242,37 @@ export function UploadTrack() {
             }
             max={new Date().toISOString().split("T")[0]}
           />
+
+          <div className="space-y-2">
+            <label
+              htmlFor="license"
+              className="block text-sm font-medium text-gray-700"
+            >
+              License
+            </label>
+            <Select
+              value={values.licenseId}
+              onValueChange={(value: string) =>
+                handleChange("licenseId", value)
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select a license" />
+              </SelectTrigger>
+              <SelectContent>
+                {licenses?.map((license) => (
+                  <SelectItem key={license.id} value={license.id}>
+                    {license.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {licenses?.find((l) => l.id === values.licenseId)?.description && (
+              <p className="mt-1 text-sm text-gray-500">
+                {licenses.find((l) => l.id === values.licenseId)?.description}
+              </p>
+            )}
+          </div>
 
           <FormTextArea
             id="description"

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -252,18 +252,17 @@ export function UploadTrack() {
             </label>
             <Select
               value={values.licenseId}
+              required
               onValueChange={(value: string) =>
                 handleChange("licenseId", value)
               }
             >
               <SelectTrigger className="w-full">
-                <SelectValue>
-                  {values.licenseId ? (
+                <SelectValue placeholder="Select a license">
+                  {values.licenseId && (
                     <div className="font-medium text-gray-900">
                       {licenses?.find((l) => l.id === values.licenseId)?.name}
                     </div>
-                  ) : (
-                    <span className="text-gray-500">Select a license</span>
                   )}
                 </SelectValue>
               </SelectTrigger>

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -138,6 +138,8 @@ export function UploadTrack() {
       },
     });
 
+  const selectedLicense = licenses?.find((l) => l.id === values.licenseId);
+
   const handleFileChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     field: "original" | "coverArt"
@@ -259,9 +261,9 @@ export function UploadTrack() {
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Select a license">
-                  {values.licenseId && (
+                  {selectedLicense && (
                     <div className="font-medium text-gray-900">
-                      {licenses?.find((l) => l.id === values.licenseId)?.name}
+                      {selectedLicense.name}
                     </div>
                   )}
                 </SelectValue>
@@ -292,20 +294,25 @@ export function UploadTrack() {
                 ))}
               </SelectContent>
             </Select>
-            {licenses?.find((l) => l.id === values.licenseId)?.description && (
+            {selectedLicense ? (
               <div className="mt-2 space-y-2">
                 <p className="text-sm text-gray-600">
-                  {licenses.find((l) => l.id === values.licenseId)?.description}
+                  {selectedLicense.description}
                 </p>
-                {licenses.find((l) => l.id === values.licenseId)
-                  ?.usageRestrictions && (
+                {selectedLicense.usageRestrictions && (
                   <p className="text-sm text-amber-600">
-                    {
-                      licenses.find((l) => l.id === values.licenseId)
-                        ?.usageRestrictions
-                    }
+                    {selectedLicense.usageRestrictions}
                   </p>
                 )}
+              </div>
+            ) : (
+              <div className="mt-2 space-y-2">
+                <p className="text-sm text-gray-600">
+                  Consider choosing a Creative Commons license to allow others
+                  to remix and build upon your work. This helps foster
+                  collaboration and enables other artists to legally use your
+                  stems in their projects while ensuring you get proper credit.
+                </p>
               </div>
             )}
           </div>

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -257,20 +257,57 @@ export function UploadTrack() {
               }
             >
               <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select a license" />
+                <SelectValue>
+                  {values.licenseId ? (
+                    <div className="font-medium text-gray-900">
+                      {licenses?.find((l) => l.id === values.licenseId)?.name}
+                    </div>
+                  ) : (
+                    <span className="text-gray-500">Select a license</span>
+                  )}
+                </SelectValue>
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent className="max-h-[400px]">
                 {licenses?.map((license) => (
-                  <SelectItem key={license.id} value={license.id}>
-                    {license.name}
+                  <SelectItem
+                    key={license.id}
+                    value={license.id}
+                    className="focus:bg-gray-50"
+                  >
+                    <div className="py-2">
+                      <div className="font-medium text-gray-900">
+                        {license.name}
+                      </div>
+                      {license.description && (
+                        <div className="text-sm text-gray-500 mt-1.5">
+                          {license.description}
+                        </div>
+                      )}
+                      {(license.usageRestrictions || license.customTerms) && (
+                        <div className="text-xs text-amber-600 mt-1.5">
+                          {license.usageRestrictions || license.customTerms}
+                        </div>
+                      )}
+                    </div>
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
             {licenses?.find((l) => l.id === values.licenseId)?.description && (
-              <p className="mt-1 text-sm text-gray-500">
-                {licenses.find((l) => l.id === values.licenseId)?.description}
-              </p>
+              <div className="mt-2 space-y-2">
+                <p className="text-sm text-gray-600">
+                  {licenses.find((l) => l.id === values.licenseId)?.description}
+                </p>
+                {licenses.find((l) => l.id === values.licenseId)
+                  ?.usageRestrictions && (
+                  <p className="text-sm text-amber-600">
+                    {
+                      licenses.find((l) => l.id === values.licenseId)
+                        ?.usageRestrictions
+                    }
+                  </p>
+                )}
+              </div>
             )}
           </div>
 

--- a/packages/frontend/src/pages/UploadTrack.tsx
+++ b/packages/frontend/src/pages/UploadTrack.tsx
@@ -285,7 +285,7 @@ export function UploadTrack() {
                         </div>
                       )}
                       {(license.usageRestrictions || license.customTerms) && (
-                        <div className="text-xs text-amber-600 mt-1.5">
+                        <div className="text-xs text-blue-600 mt-1.5">
                           {license.usageRestrictions || license.customTerms}
                         </div>
                       )}
@@ -300,7 +300,7 @@ export function UploadTrack() {
                   {selectedLicense.description}
                 </p>
                 {selectedLicense.usageRestrictions && (
-                  <p className="text-sm text-amber-600">
+                  <p className="text-sm text-blue-600">
                     {selectedLicense.usageRestrictions}
                   </p>
                 )}


### PR DESCRIPTION
This PR introduces a comprehensive track licensing system to allow creators to specify usage terms for their tracks. Key changes include:

- Add `License` model with support for Creative Commons and custom licenses
- Add database seeding system with initial license types and feature flags
- Add `/api/licenses` endpoint to fetch available licenses
- Update track creation to require a license selection
- Add caching headers for media endpoints (2min TTL for testing)
- Fix release date validation to require proper datetime format
- Make genres field required for tracks

The licensing system supports:
- CC BY (Attribution)
- CC BY-SA (Attribution-ShareAlike)
- CC BY-NC (Attribution-NonCommercial)
- CC BY-NC-SA (Attribution-NonCommercial-ShareAlike)
- CC BY-ND (Attribution-NoDerivs)
- CC BY-NC-ND (Attribution-NonCommercial-NoDerivs)
- All Rights Reserved
- Custom licensing options

Each license type specifies permissions for remixing, sharing, commercial use, and stem usage, along with attribution requirements and territory restrictions where applicable.