### PR TITLE
Fix local Docker builds by setting empty registry prefix and remove unused import in ManageStorage

### DIFF
--- a/packages/frontend/src/pages/ManageStorage/index.tsx
+++ b/packages/frontend/src/pages/ManageStorage/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { api } from "@/api/client";
-import { useAuth } from "@/contexts/AuthContext";
 import { formatSeconds } from "@/utils/formatSeconds";
 import { auth } from "@/utils/auth";
 
@@ -14,7 +13,6 @@ interface StorageQuota {
 }
 
 export function ManageStorage() {
-  const { user } = useAuth();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [quota, setQuota] = useState<StorageQuota | null>(null);

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -374,7 +374,14 @@ build_workspace() {
     
     # Set empty registry prefix for local builds to avoid Docker Hub lookup
     export REGISTRY_PREFIX=""
-    docker compose --profile build build workspace-apt-base workspace
+    
+    # Build base image first
+    debug_log "Building workspace-apt-base..."
+    docker compose --profile build build workspace-apt-base
+    
+    # Then build workspace image
+    debug_log "Building workspace..."
+    docker compose --profile build build workspace
 }
 
 # Function to build media service (used by other build commands)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -320,6 +320,9 @@ build_service() {
     debug_log "Building service: $service_name"
     debug_log "Using temporary file: $temp_file"
     
+    # Set empty registry prefix for local builds to avoid Docker Hub lookup
+    export REGISTRY_PREFIX=""
+    
     # Add --progress=plain when debug is enabled
     local build_args=""
     if [ "$DEBUG" = true ]; then
@@ -355,6 +358,8 @@ build_service() {
 # Function to build tools image (used by other build commands)
 build_tools() {
     debug_log "Building tools image..."
+    # Set empty registry prefix for local builds to avoid Docker Hub lookup
+    export REGISTRY_PREFIX=""
     docker compose --profile build build tools
 }
 
@@ -367,6 +372,8 @@ build_workspace() {
     debug_log "Running distribute-env.sh for .env.docker"
     ./scripts/distribute-env.sh .env.docker
     
+    # Set empty registry prefix for local builds to avoid Docker Hub lookup
+    export REGISTRY_PREFIX=""
     docker compose --profile build build workspace-apt-base workspace
 }
 


### PR DESCRIPTION
This PR addresses two issues:
- Updates the `deploy.sh` script to set an empty `REGISTRY_PREFIX` for local Docker builds, preventing unnecessary Docker Hub lookups and ensuring images are built locally.
- Cleans up the `ManageStorage` page in the frontend by removing an unused `useAuth` import and its related code.