### PR TITLE
Fix auth service signup flow and make audio conversion auth optional

### DIFF
--- a/packages/frontend/src/hooks/useAudioFileConversion.tsx
+++ b/packages/frontend/src/hooks/useAudioFileConversion.tsx
@@ -37,7 +37,6 @@ export function useAudioFileConversion({
       const checkStatus = async () => {
         try {
           const token = getToken();
-          if (!token) return;
 
           const statusUrl = stem
             ? `/api/track/${track.id}/stem/${stem.id}/audio-conversion-status`
@@ -50,7 +49,7 @@ export function useAudioFileConversion({
 
           const response = await fetch(`${statusUrl}?format=${format}`, {
             headers: {
-              Authorization: `Bearer ${token}`,
+              ...(token && { Authorization: `Bearer ${token}` }),
             },
             signal: currentController.signal,
           });
@@ -107,13 +106,12 @@ export function useAudioFileConversion({
     try {
       setIsConverting(true);
       const token = getToken();
-      if (!token) return;
 
       const response = await fetch(`/api/track/${track.id}/convert-audio`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+          ...(token && { Authorization: `Bearer ${token}` }),
         },
         body: JSON.stringify({
           type,


### PR DESCRIPTION
This PR addresses two key issues:

**Authentication Service Improvements:**
- Fixes invite code handling in the signup flow by properly scoping the `inviteCode` variable
- Adds proper error handling with try-catch block around user creation
- Corrects the field name from `freeQuotaBytes` to `freeQuotaSeconds` for consistency with the data model
- Ensures invite code usage count is only incremented after successful user creation

**Audio Conversion Auth Flexibility:**
- Makes authentication optional for audio conversion status checks and requests
- Uses conditional header spreading to only include Authorization header when token is present
- Allows unauthenticated users to check conversion status and request conversions (useful for public tracks)

These changes improve the robustness of user registration and make the audio conversion system more flexible for different access patterns.